### PR TITLE
fix: correctness fixes, per-section diffing, and performance improvem…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,11 +154,15 @@ benchmark:
 	xcodebuild test \
 		-workspace ListKit.xcworkspace \
 		-scheme Benchmarks \
+		-configuration Release \
+		ENABLE_TESTABILITY=YES \
 		-destination '$(DESTINATION)' \
 		-derivedDataPath $(DERIVED_DATA) \
 		| xcpretty || xcodebuild test \
 		-workspace ListKit.xcworkspace \
 		-scheme Benchmarks \
+		-configuration Release \
+		ENABLE_TESTABILITY=YES \
 		-destination '$(DESTINATION)' \
 		-derivedDataPath $(DERIVED_DATA)
 

--- a/Sources/ListKit/Algorithm/HeckelDiff.swift
+++ b/Sources/ListKit/Algorithm/HeckelDiff.swift
@@ -134,9 +134,12 @@ enum HeckelDiff {
 
         // Pass 6: Collect results
         var deletes: [Int] = []
+        deletes.reserveCapacity(old.count)
         var inserts: [Int] = []
+        inserts.reserveCapacity(new.count)
         var moves: [(from: Int, to: Int)] = []
         var matched: [(old: Int, new: Int)] = []
+        matched.reserveCapacity(min(old.count, new.count))
 
         for (oldIdx, entry) in OA.enumerated() {
             if case .symbolTable = entry {


### PR DESCRIPTION
…ents

- Fix cross-boundary item transitions in SectionedDiff (items moving between deleted/inserted sections were silently dropped)
- Replace global O(n) dictionary diffing with per-section HeckelDiff that skips unchanged sections entirely (no-change diff: 94x faster than IGListKit)
- Serialize completion-handler apply() to prevent races on currentSnapshot
- Add O(1) fast-path methods for cellForItemAt and numberOfItemsInSection
- Add O(1) contains via itemSet in DiffableDataSourceSectionSnapshot
- Optimize visibleItems with single-pass top-down traversal
- Batch deletion in section snapshots instead of recursive per-item
- Add DEBUG duplicate-item validation in appendItems
- Fix deleteSections double-counting with duplicate section IDs
- Add reserveCapacity throughout HeckelDiff and SectionedDiff
- Run benchmarks in Release configuration for production-representative numbers
- Update README with Release-mode benchmark numbers
- Add 6 new tests covering cross-boundary items, fast paths, edge cases