### PR TITLE
Performance optimizations and API gap fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ All benchmarks run in **Release configuration** with median-of-15 and 5 warmup i
 
 | Operation | ListKit | Apple | Speedup |
 |:---|---:|---:|---:|
-| Build 10k items | 0.002 ms | 1.308 ms | **805.0x** |
-| Build 50k items | 0.006 ms | 6.106 ms | **957.7x** |
-| Build 100 sections x 100 | 0.058 ms | 4.164 ms | **71.6x** |
-| Delete 5k from 10k | 1.176 ms | 2.323 ms | **2.0x** |
-| Delete 25/50 sections | 0.042 ms | 1.760 ms | **41.6x** |
-| Reload 5k items | 0.111 ms | 1.582 ms | **14.3x** |
-| Query itemIdentifiers 100x | 0.052 ms | 46.258 ms | **884.6x** |
+| Build 10k items | 0.002 ms | 1.286 ms | **857.6x** |
+| Build 50k items | 0.006 ms | 6.324 ms | **1,054.0x** |
+| Build 100 sections x 100 | 0.057 ms | 4.227 ms | **74.8x** |
+| Delete 5k from 10k | 1.184 ms | 2.462 ms | **2.1x** |
+| Delete 25/50 sections | 0.043 ms | 1.934 ms | **44.8x** |
+| Reload 5k items | 0.100 ms | 1.632 ms | **16.3x** |
+| Query itemIdentifiers 100x | 0.054 ms | 48.326 ms | **886.7x** |
 
 ListKit snapshots are pure Swift value types with flat array storage and a lazy reverse index. Apple's `NSDiffableDataSourceSnapshot` is backed by Objective-C runtime overhead and per-query hashing.
 
@@ -238,10 +238,10 @@ Both libraries implement Paul Heckel's O(n) diff. IGListKit's is Objective-C++; 
 
 | Operation | IGListKit | ListKit | Notes |
 |:---|---:|---:|:---|
-| Diff 10k (50% overlap) | 11.8 ms | 13.1 ms | Near-parity at common scale |
-| Diff 50k (50% overlap) | 55.4 ms | 75.9 ms | IGListKit's C++ is faster for raw diffing |
-| Diff no-change 10k | 10.4 ms | 0.1 ms | **94x** — per-section skip makes this free |
-| Diff shuffle 10k | 10.3 ms | 4.5 ms | **2.3x** ListKit wins all-moves case |
+| Diff 10k (50% overlap) | 11.6 ms | 11.9 ms | Near-parity at common scale |
+| Diff 50k (50% overlap) | 64.0 ms | 70.9 ms | IGListKit's C++ is faster for raw diffing |
+| Diff no-change 10k | 10.6 ms | 0.1 ms | **91x** — per-section skip makes this free |
+| Diff shuffle 10k | 11.6 ms | 3.4 ms | **3.4x** ListKit wins all-moves case |
 
 Per-section diffing skips unchanged sections entirely — the common case for incremental UI updates. For heavy churn (50% overlap), IGListKit's Obj-C++ wins on raw throughput, but ListKit provides sectioned structure, `Sendable` safety, and full `UICollectionViewDiffableDataSource` compatibility that IGListKit doesn't.
 
@@ -251,11 +251,11 @@ ReactiveCollectionsKit wraps Apple's `NSDiffableDataSourceSnapshot` with type-er
 
 | Operation | ListKit | ReactiveCollectionsKit | Apple | Speedup vs RC |
 |:---|---:|---:|---:|---:|
-| Build 10k items | 0.004 ms | 7.6 ms | 1.2 ms | **1,894x** |
-| Build 50k items | 0.014 ms | 37.8 ms | — | **2,701x** |
-| Build 100 sections x 100 | 0.063 ms | 7.6 ms | 4.1 ms | **121x** |
+| Build 10k items | 0.006 ms | 7.9 ms | 1.3 ms | **1,311x** |
+| Build 50k items | 0.033 ms | 36.7 ms | — | **1,113x** |
+| Build 100 sections x 100 | 0.058 ms | 7.8 ms | 4.7 ms | **134x** |
 
-Type erasure alone (`eraseToAnyViewModel()`) costs 7.6 ms for 10k cells — more than ListKit's entire snapshot build at the same scale.
+Type erasure alone (`eraseToAnyViewModel()`) costs 7.3 ms for 10k cells — more than ListKit's entire snapshot build at the same scale.
 
 Run benchmarks with:
 
@@ -297,7 +297,7 @@ Sources/
     Configurations/ # SimpleList, GroupedList, OutlineList
     Extensions/     # LayoutHelpers, CellViewModel+Identifiable
 Tests/
-  ListKitTests/     # 82 tests — diff, snapshot, data source
+  ListKitTests/     # 91 tests — diff, snapshot, data source
   ListsTests/       # 43 tests — builder, configurations, view models
   Benchmarks/       # 18 benchmarks — Apple, IGListKit, ReactiveCollectionsKit
 Example/            # 5-tab demo app

--- a/Sources/ListKit/Algorithm/StagedChangeset.swift
+++ b/Sources/ListKit/Algorithm/StagedChangeset.swift
@@ -22,4 +22,29 @@ struct StagedChangeset<SectionID: Hashable, ItemID: Hashable>: Sendable {
             && itemReloads.isEmpty
             && itemReconfigures.isEmpty
     }
+
+    var hasStructuralChanges: Bool {
+        !sectionDeletes.isEmpty
+            || !sectionInserts.isEmpty
+            || !sectionMoves.isEmpty
+            || !itemDeletes.isEmpty
+            || !itemInserts.isEmpty
+            || !itemMoves.isEmpty
+    }
+}
+
+extension StagedChangeset: Equatable {
+    static func == (lhs: StagedChangeset, rhs: StagedChangeset) -> Bool {
+        lhs.sectionDeletes == rhs.sectionDeletes
+            && lhs.sectionInserts == rhs.sectionInserts
+            && lhs.sectionMoves.count == rhs.sectionMoves.count
+            && zip(lhs.sectionMoves, rhs.sectionMoves).allSatisfy { $0.from == $1.from && $0.to == $1.to }
+            && lhs.sectionReloads == rhs.sectionReloads
+            && lhs.itemDeletes == rhs.itemDeletes
+            && lhs.itemInserts == rhs.itemInserts
+            && lhs.itemMoves.count == rhs.itemMoves.count
+            && zip(lhs.itemMoves, rhs.itemMoves).allSatisfy { $0.from == $1.from && $0.to == $1.to }
+            && lhs.itemReloads == rhs.itemReloads
+            && lhs.itemReconfigures == rhs.itemReconfigures
+    }
 }

--- a/Sources/ListKit/DataSource/CollectionViewDiffableDataSource.swift
+++ b/Sources/ListKit/DataSource/CollectionViewDiffableDataSource.swift
@@ -62,6 +62,21 @@ public final class CollectionViewDiffableDataSource<
             return
         }
 
+        // Fast path: only reloads/reconfigures, no structural changes.
+        // Skip performBatchUpdates entirely — apply directly without the batch overhead.
+        if !changeset.hasStructuralChanges {
+            if !changeset.sectionReloads.isEmpty {
+                collectionView.reloadSections(changeset.sectionReloads)
+            }
+            if !changeset.itemReloads.isEmpty {
+                collectionView.reloadItems(at: changeset.itemReloads)
+            }
+            if !changeset.itemReconfigures.isEmpty {
+                collectionView.reconfigureItems(at: changeset.itemReconfigures)
+            }
+            return
+        }
+
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             collectionView.performBatchUpdates {
                 // Deletes (old indices)

--- a/Sources/Lists/DataSource/ListDataSource.swift
+++ b/Sources/Lists/DataSource/ListDataSource.swift
@@ -72,6 +72,14 @@ public final class ListDataSource<SectionID: Hashable & Sendable, Item: CellView
         dataSource.indexPath(for: item)
     }
 
+    public func sectionIdentifier(for index: Int) -> SectionID? {
+        dataSource.sectionIdentifier(for: index)
+    }
+
+    public func index(for sectionIdentifier: SectionID) -> Int? {
+        dataSource.index(for: sectionIdentifier)
+    }
+
     // MARK: - Supplementary Views
 
     public var supplementaryViewProvider: CollectionViewDiffableDataSource<SectionID, Item>.SupplementaryViewProvider? {

--- a/Sources/Lists/Extensions/CellViewModel+Identifiable.swift
+++ b/Sources/Lists/Extensions/CellViewModel+Identifiable.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// Automatic id-based `Hashable`/`Equatable` for `CellViewModel & Identifiable`.
+///
+/// **Important:** Only `id` is used for equality and hashing. Properties beyond `id`
+/// (e.g. title, subtitle, image) are **not** considered by the diff — the algorithm
+/// treats two items with the same `id` as identical even if their content differs.
+///
+/// To update visible cells after content-only changes, mark items for reconfigure:
+/// ```swift
+/// snapshot.reconfigureItems([updatedItem])
+/// ```
 public extension CellViewModel where Self: Identifiable, ID: Hashable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id

--- a/Tests/ListKitTests/SectionedDiffTests.swift
+++ b/Tests/ListKitTests/SectionedDiffTests.swift
@@ -356,4 +356,44 @@ struct SectionedDiffTests {
         #expect(changeset.itemInserts.isEmpty)
         #expect(changeset.itemMoves.isEmpty)
     }
+
+    // MARK: - StagedChangeset Properties
+
+    @Test func changesetHasStructuralChanges() {
+        var old = DiffableDataSourceSnapshot<String, Int>()
+        old.appendSections(["A"])
+        old.appendItems([1, 2, 3], toSection: "A")
+
+        // Reconfigure-only: no structural changes
+        var reconfigureOnly = DiffableDataSourceSnapshot<String, Int>()
+        reconfigureOnly.appendSections(["A"])
+        reconfigureOnly.appendItems([1, 2, 3], toSection: "A")
+        reconfigureOnly.reconfigureItems([1])
+
+        let reconfigureChangeset = SectionedDiff.diff(old: old, new: reconfigureOnly)
+        #expect(!reconfigureChangeset.isEmpty)
+        #expect(!reconfigureChangeset.hasStructuralChanges)
+
+        // Structural: item insert
+        var withInsert = DiffableDataSourceSnapshot<String, Int>()
+        withInsert.appendSections(["A"])
+        withInsert.appendItems([1, 2, 3, 4], toSection: "A")
+
+        let insertChangeset = SectionedDiff.diff(old: old, new: withInsert)
+        #expect(insertChangeset.hasStructuralChanges)
+    }
+
+    @Test func changesetEquatable() {
+        var old = DiffableDataSourceSnapshot<String, Int>()
+        old.appendSections(["A"])
+        old.appendItems([1, 2], toSection: "A")
+
+        var new = DiffableDataSourceSnapshot<String, Int>()
+        new.appendSections(["A"])
+        new.appendItems([1, 2, 3], toSection: "A")
+
+        let changeset1 = SectionedDiff.diff(old: old, new: new)
+        let changeset2 = SectionedDiff.diff(old: old, new: new)
+        #expect(changeset1 == changeset2)
+    }
 }


### PR DESCRIPTION
## Summary

- **HeckelDiff struct optimization**: Convert `SymbolEntry` from class to struct, eliminating per-element heap allocations and ARC overhead during diffing
- **Reconfigure-only fast path**: When a changeset contains only reloads/reconfigures (no structural changes), skip `performBatchUpdates` entirely and apply directly
- **Snapshot `isEmpty` property**: New `isEmpty` computed property for checking empty state without materializing item arrays
- **`deleteItems` reverse-map fast path**: When the lazy reverse map exists, only scan affected sections instead of linear scan across all sections
- **`StagedChangeset` improvements**: Added `hasStructuralChanges` property and `Equatable` conformance for testability
- **ListDataSource query forwarding**: Expose `sectionIdentifier(for:)` and `index(for:)` through the high-level API
- **LiveExample fix**: Replace manual `visibleCells` iteration with proper `reconfigureItems` API
- **CellViewModel+Identifiable doc comment**: Document the id-only equality/hashing behavior and `reconfigureItems` pattern
- **9 new tests**: `isEmpty`, `deleteItemsWithReverseMap`, `deleteSectionsDeduplication`, `itemIdentifierFastPath`, `changesetHasStructuralChanges`, `changesetEquatable`, and more
- **Updated benchmarks**: Re-recorded all benchmark numbers in README

## Test plan

- [x] All 91 ListKit tests pass
- [x] All 43 Lists tests pass (134 total)
- [x] All 18 benchmarks pass in Release configuration
- [x] Pre-commit hook (SwiftFormat + lint) passes