### PR TITLE
Replace SwiftLint with SwiftFormat lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 	@echo ""
 	@echo "  $(BOLD)◆ Code Quality$(RESET)"
 	@echo "  $(DIM)──────────────────────────────────────────────────────────────$(RESET)"
-	@printf "    $(CYAN)%-24s$(RESET) %s\n" "lint" "Run SwiftLint on Sources/ and Tests/"
+	@printf "    $(CYAN)%-24s$(RESET) %s\n" "lint" "Lint Sources/, Tests/, and Example/ with SwiftFormat"
 	@printf "    $(CYAN)%-24s$(RESET) %s\n" "format" "Format code with SwiftFormat"
 	@printf "    $(CYAN)%-24s$(RESET) %s\n" "install-hooks" "Install git pre-commit hook"
 	@echo ""
@@ -171,7 +171,7 @@ benchmark:
 # =============================================================================
 
 lint:
-	swiftlint lint --strict Sources/ Tests/
+	swiftformat --lint Sources/ Tests/ Example/
 
 format:
 	swiftformat Sources/ Tests/ Example/


### PR DESCRIPTION
## Summary

- Replace `swiftlint lint --strict` with `swiftformat --lint` in Makefile's `lint` target
- Update help text to reflect the change
- `make lint` now runs `swiftformat --lint Sources/ Tests/ Example/` — consistent with the formatter already used by the pre-commit hook

## Test plan

- [x] `make lint` passes with zero issues (0/45 files require formatting)