### PR TITLE
Add MIT license and fix SPM version for 0.0.1 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hesham Salman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A fast, pure-Swift diffable data source for `UICollectionView`. Drop-in replacem
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Iron-Ham/ListKit", from: "0.1.0"),
+    .package(url: "https://github.com/Iron-Ham/ListKit", from: "0.0.1"),
 ]
 ```
 


### PR DESCRIPTION
## Summary
- Add MIT License file (Copyright (c) 2026 Hesham Salman)
- Fix SPM version in README from `0.1.0` to `0.0.1` to match the initial release tag

## Test plan
- [ ] Verify `LICENSE` file is present and correctly formatted
- [ ] Verify README SPM instructions reference `from: "0.0.1"`