### PR TITLE
Serialize async apply and pre-release correctness fixes

### DIFF
--- a/Sources/ListKit/Algorithm/HeckelDiff.swift
+++ b/Sources/ListKit/Algorithm/HeckelDiff.swift
@@ -56,12 +56,12 @@ enum HeckelDiff {
             return DiffResult(deletes: [], inserts: [], moves: [], matched: [])
         }
 
-        var entries: [SymbolEntry] = []
+        var entries = ContiguousArray<SymbolEntry>()
         entries.reserveCapacity(old.count + new.count)
         var symbolTable: [T: Int] = [:]
         symbolTable.reserveCapacity(old.count + new.count)
-        var NA: [ArrayEntry] = []
-        var OA: [ArrayEntry] = []
+        var NA = ContiguousArray<ArrayEntry>()
+        var OA = ContiguousArray<ArrayEntry>()
 
         // Pass 1: Scan new array
         NA.reserveCapacity(new.count)
@@ -147,6 +147,7 @@ enum HeckelDiff {
         var inserts: [Int] = []
         inserts.reserveCapacity(new.count)
         var moves: [(from: Int, to: Int)] = []
+        moves.reserveCapacity(min(old.count, new.count))
         var matched: [(old: Int, new: Int)] = []
         matched.reserveCapacity(min(old.count, new.count))
 


### PR DESCRIPTION
## Summary

- **Serialize async `apply()`** through `applyTask` chaining to prevent race conditions when called rapidly from multiple `Task` blocks. Previously only the completion-handler variant was serialized.
- **Clean stale reload/reconfigure sets** on `deleteItems`, `deleteSections`, and `deleteAllItems` to prevent unbounded set growth when items are marked for reload/reconfigure then deleted before the next apply.
- **Single-section fast path** in `SectionedDiff` — skip cross-section move dictionary allocation when only one section exists (common case for flat lists).
- **ContiguousArray + reserveCapacity** for HeckelDiff internals — eliminates Obj-C bridging checks and reduces allocations for move result arrays.

## Test plan

- [x] All 164 tests pass (`make test` — 91 ListKitTests + 73 ListsTests)
- [x] SwiftFormat lint passes via pre-commit hook
- [ ] Verify rapid `Task { await apply(...) }` calls serialize correctly in example app
- [ ] Run `make benchmark` to confirm no regression from ContiguousArray/reserveCapacity changes