### PR TITLE
Add first-class SwiftUI support

### DIFF
--- a/Sources/Lists/Configurations/OutlineList.swift
+++ b/Sources/Lists/Configurations/OutlineList.swift
@@ -1,7 +1,7 @@
 import ListKit
 import UIKit
 
-public struct OutlineItem<Item: CellViewModel>: Sendable {
+public struct OutlineItem<Item: CellViewModel>: Sendable, Equatable {
     public let item: Item
     public let children: [OutlineItem<Item>]
     public let isExpanded: Bool

--- a/Sources/Lists/Protocols/SectionModel.swift
+++ b/Sources/Lists/Protocols/SectionModel.swift
@@ -1,4 +1,4 @@
-public struct SectionModel<SectionID: Hashable & Sendable, Item: CellViewModel>: Sendable {
+public struct SectionModel<SectionID: Hashable & Sendable, Item: CellViewModel>: Sendable, Equatable {
     public let id: SectionID
     public let items: [Item]
     public let header: String?

--- a/Sources/Lists/SwiftUI/GroupedListView.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import UIKit
+
+@MainActor
+public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewModel>: UIViewRepresentable {
+    public let sections: [SectionModel<SectionID, Item>]
+    public let appearance: UICollectionLayoutListConfiguration.Appearance
+    public var onSelect: (@MainActor (Item) -> Void)?
+
+    public init(
+        sections: [SectionModel<SectionID, Item>],
+        appearance: UICollectionLayoutListConfiguration.Appearance = .insetGrouped,
+        onSelect: (@MainActor (Item) -> Void)? = nil
+    ) {
+        self.sections = sections
+        self.appearance = appearance
+        self.onSelect = onSelect
+    }
+
+    public func makeUIView(context: Context) -> UICollectionView {
+        let list = GroupedList<SectionID, Item>(appearance: appearance)
+        list.onSelect = onSelect
+        context.coordinator.list = list
+        context.coordinator.previousSections = sections
+        Task {
+            await list.setSections(sections, animatingDifferences: false)
+        }
+        return list.collectionView
+    }
+
+    public func updateUIView(_: UICollectionView, context: Context) {
+        guard let list = context.coordinator.list else { return }
+        list.onSelect = onSelect
+        guard sections != context.coordinator.previousSections else { return }
+        context.coordinator.previousSections = sections
+        context.coordinator.updateTask?.cancel()
+        context.coordinator.updateTask = Task {
+            await list.setSections(sections)
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    @MainActor
+    public final class Coordinator {
+        var list: GroupedList<SectionID, Item>?
+        var previousSections: [SectionModel<SectionID, Item>]?
+        var updateTask: Task<Void, Never>?
+    }
+}

--- a/Sources/Lists/SwiftUI/OutlineListView.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import UIKit
+
+@MainActor
+public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
+    public let items: [OutlineItem<Item>]
+    public let appearance: UICollectionLayoutListConfiguration.Appearance
+    public var onSelect: (@MainActor (Item) -> Void)?
+
+    public init(
+        items: [OutlineItem<Item>],
+        appearance: UICollectionLayoutListConfiguration.Appearance = .sidebar,
+        onSelect: (@MainActor (Item) -> Void)? = nil
+    ) {
+        self.items = items
+        self.appearance = appearance
+        self.onSelect = onSelect
+    }
+
+    public func makeUIView(context: Context) -> UICollectionView {
+        let list = OutlineList<Item>(appearance: appearance)
+        list.onSelect = onSelect
+        context.coordinator.list = list
+        context.coordinator.previousItems = items
+        Task {
+            await list.setItems(items, animatingDifferences: false)
+        }
+        return list.collectionView
+    }
+
+    public func updateUIView(_: UICollectionView, context: Context) {
+        guard let list = context.coordinator.list else { return }
+        list.onSelect = onSelect
+        guard items != context.coordinator.previousItems else { return }
+        context.coordinator.previousItems = items
+        context.coordinator.updateTask?.cancel()
+        context.coordinator.updateTask = Task {
+            await list.setItems(items)
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    @MainActor
+    public final class Coordinator {
+        var list: OutlineList<Item>?
+        var previousItems: [OutlineItem<Item>]?
+        var updateTask: Task<Void, Never>?
+    }
+}

--- a/Sources/Lists/SwiftUI/SimpleListView.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import UIKit
+
+@MainActor
+public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
+    public let items: [Item]
+    public let appearance: UICollectionLayoutListConfiguration.Appearance
+    public var onSelect: (@MainActor (Item) -> Void)?
+
+    public init(
+        items: [Item],
+        appearance: UICollectionLayoutListConfiguration.Appearance = .plain,
+        onSelect: (@MainActor (Item) -> Void)? = nil
+    ) {
+        self.items = items
+        self.appearance = appearance
+        self.onSelect = onSelect
+    }
+
+    public func makeUIView(context: Context) -> UICollectionView {
+        let list = SimpleList<Item>(appearance: appearance)
+        list.onSelect = onSelect
+        context.coordinator.list = list
+        context.coordinator.previousItems = items
+        Task {
+            await list.setItems(items, animatingDifferences: false)
+        }
+        return list.collectionView
+    }
+
+    public func updateUIView(_: UICollectionView, context: Context) {
+        guard let list = context.coordinator.list else { return }
+        list.onSelect = onSelect
+        guard items != context.coordinator.previousItems else { return }
+        context.coordinator.previousItems = items
+        context.coordinator.updateTask?.cancel()
+        context.coordinator.updateTask = Task {
+            await list.setItems(items)
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    @MainActor
+    public final class Coordinator {
+        var list: SimpleList<Item>?
+        var previousItems: [Item]?
+        var updateTask: Task<Void, Never>?
+    }
+}

--- a/Sources/Lists/SwiftUI/SwiftUICellViewModel.swift
+++ b/Sources/Lists/SwiftUI/SwiftUICellViewModel.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import UIKit
+
+/// A ``CellViewModel`` that uses a SwiftUI `body` to define cell content.
+///
+/// Conformers provide a SwiftUI `View` via `body` and optionally override
+/// `accessories` to add cell accessories like disclosure indicators.
+///
+/// The default `configure(_:)` implementation renders `body` inside a
+/// `UIHostingConfiguration`. **Do not override `configure(_:)`** — doing so
+/// will cause `body` and `accessories` to be silently ignored.
+public protocol SwiftUICellViewModel: CellViewModel where Cell == UICollectionViewListCell {
+    associatedtype Content: View
+    @MainActor var body: Content { get }
+    @MainActor var accessories: [UICellAccessory] { get }
+}
+
+public extension SwiftUICellViewModel {
+    @MainActor var accessories: [UICellAccessory] {
+        []
+    }
+
+    @MainActor func configure(_ cell: UICollectionViewListCell) {
+        cell.contentConfiguration = UIHostingConfiguration { body }
+        cell.accessories = accessories
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SwiftUICellViewModel` protocol for defining cell content with a SwiftUI `body` instead of UIKit's `configure()`, with a default `accessories` property for non-default cell accessories
- Add `UIViewRepresentable` wrappers (`SimpleListView`, `GroupedListView`, `OutlineListView`) for all three pre-built list configurations
- Update the example app to use the shipped wrappers instead of local prototypes

## Test plan

- [ ] `make build` compiles without errors/warnings under Swift 6
- [ ] `make test` — all 73 tests pass
- [ ] `make lint` — no formatting issues
- [ ] Example app demonstrates `SwiftUICellViewModel` with `ContactItem` using `body` + `accessories`
- [ ] Verify `SimpleListView`, `GroupedListView`, `OutlineListView` wrappers work in SwiftUI previews