### PR TITLE
Add SwiftUI feature parity for all list configurations

### DIFF
--- a/Example/Sources/SceneDelegate.swift
+++ b/Example/Sources/SceneDelegate.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -18,6 +19,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             makeTab(MixedExampleViewController(), title: "Mixed", icon: "square.stack.3d.up"),
             makeTab(OutlineExampleViewController(), title: "Outline", icon: "list.triangle"),
             makeTab(SwiftUIExampleViewController(), title: "SwiftUI", icon: "swift"),
+            makeTab(
+                UIHostingController(rootView: SwiftUIWrappersExampleView()),
+                title: "Wrappers",
+                icon: "rectangle.on.rectangle"
+            ),
             makeTab(LiveExampleViewController(), title: "Live", icon: "chart.line.uptrend.xyaxis"),
         ]
 

--- a/Example/Sources/SwiftUIExampleViewController.swift
+++ b/Example/Sources/SwiftUIExampleViewController.swift
@@ -29,8 +29,8 @@ final class SwiftUIExampleViewController: UIViewController {
             ContactRow(name: name, role: role, status: status, avatarColor: avatarColor)
         }
 
-        var accessories: [UICellAccessory] {
-            [.disclosureIndicator()]
+        var accessories: [ListAccessory] {
+            [.disclosureIndicator]
         }
     }
 

--- a/Example/Sources/SwiftUIWrappersExampleView.swift
+++ b/Example/Sources/SwiftUIWrappersExampleView.swift
@@ -1,0 +1,247 @@
+import Lists
+import SwiftUI
+import UIKit
+
+/// Demonstrates the shipped UIViewRepresentable wrappers: SimpleListView,
+/// GroupedListView, and OutlineListView — all driven by SwiftUI @State.
+struct SwiftUIWrappersExampleView: View {
+    enum Demo: String, CaseIterable {
+        case simple = "Simple"
+        case grouped = "Grouped"
+        case outline = "Outline"
+    }
+
+    @State private var selectedDemo: Demo = .simple
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Demo", selection: $selectedDemo) {
+                ForEach(Demo.allCases, id: \.self) { demo in
+                    Text(demo.rawValue).tag(demo)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            switch selectedDemo {
+            case .simple:
+                SimpleDemoView()
+            case .grouped:
+                GroupedDemoView()
+            case .outline:
+                OutlineDemoView()
+            }
+        }
+    }
+}
+
+// MARK: - Simple Demo (Inline Content + Swipe Actions + Context Menu)
+
+/// Uses the inline content closure API — no separate struct needed.
+/// Also demonstrates trailing swipe actions and context menus (long-press preview).
+private struct SimpleDemoView: View {
+    @State private var fruits: [Fruit] = [
+        Fruit(name: "Apple", emoji: "🍎"),
+        Fruit(name: "Banana", emoji: "🍌"),
+        Fruit(name: "Cherry", emoji: "🍒"),
+        Fruit(name: "Grape", emoji: "🍇"),
+        Fruit(name: "Mango", emoji: "🥭"),
+        Fruit(name: "Orange", emoji: "🍊"),
+        Fruit(name: "Peach", emoji: "🍑"),
+        Fruit(name: "Strawberry", emoji: "🍓"),
+    ]
+
+    var body: some View {
+        SimpleListView(
+            items: fruits,
+            onSelect: { fruit in
+                print("Selected: \(fruit.name)")
+            },
+            trailingSwipeActionsProvider: { fruit in
+                let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { _, _, completion in
+                    fruits.removeAll { $0.id == fruit.id }
+                    completion(true)
+                }
+                return UISwipeActionsConfiguration(actions: [deleteAction])
+            },
+            contextMenuProvider: { fruit in
+                UIContextMenuConfiguration(actionProvider: { _ in
+                    let favorite = UIAction(title: "Favorite", image: UIImage(systemName: "heart")) { _ in
+                        print("Favorited \(fruit.name)")
+                    }
+                    let share = UIAction(title: "Share", image: UIImage(systemName: "square.and.arrow.up")) { _ in
+                        print("Shared \(fruit.name)")
+                    }
+                    return UIMenu(children: [favorite, share])
+                })
+            }
+        ) { fruit in
+            HStack {
+                Text(fruit.emoji)
+                    .font(.title2)
+                Text(fruit.name)
+            }
+            .padding(.vertical, 4)
+        }
+        .overlay(alignment: .bottom) {
+            Button("Shuffle") { fruits.shuffle() }
+                .buttonStyle(.borderedProminent)
+                .padding()
+        }
+    }
+}
+
+// MARK: - Grouped Demo (Pull-to-Refresh + ListAccessory + Context Menu)
+
+private struct GroupedDemoView: View {
+    @State private var languages = [
+        LanguageItem(name: "Swift", year: 2014),
+        LanguageItem(name: "Kotlin", year: 2011),
+        LanguageItem(name: "Rust", year: 2010),
+    ]
+
+    @State private var frameworks = [
+        LanguageItem(name: "SwiftUI", year: 2019),
+        LanguageItem(name: "Jetpack Compose", year: 2021),
+        LanguageItem(name: "Flutter", year: 2017),
+    ]
+
+    var body: some View {
+        GroupedListView(
+            sections: [
+                SectionModel(
+                    id: "languages",
+                    items: languages,
+                    header: "Languages",
+                    footer: "\(languages.count) items"
+                ),
+                SectionModel(
+                    id: "frameworks",
+                    items: frameworks,
+                    header: "Frameworks",
+                    footer: "\(frameworks.count) items"
+                ),
+            ],
+            onSelect: { item in
+                print("Selected: \(item.name)")
+            },
+            onRefresh: {
+                // Simulate network fetch
+                try? await Task.sleep(for: .seconds(1))
+                languages.shuffle()
+                frameworks.shuffle()
+            }
+        )
+        .overlay(alignment: .bottom) {
+            Button("Shuffle") {
+                languages.shuffle()
+                frameworks.shuffle()
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+        }
+    }
+}
+
+// MARK: - Outline Demo (Inline Content + Pull-to-Refresh + Context Menu)
+
+/// Uses the inline content closure API for outline lists — no CellViewModel needed.
+/// Also demonstrates pull-to-refresh and context menus on outline items.
+private struct OutlineDemoView: View {
+    @State private var items: [OutlineItem<EmojiCategory>] = [
+        OutlineItem(
+            item: EmojiCategory(name: "Animals"),
+            children: [
+                OutlineItem(item: EmojiCategory(name: "🐶 Dog")),
+                OutlineItem(item: EmojiCategory(name: "🐱 Cat")),
+                OutlineItem(item: EmojiCategory(name: "🐦 Bird")),
+            ],
+            isExpanded: true
+        ),
+        OutlineItem(
+            item: EmojiCategory(name: "Food"),
+            children: [
+                OutlineItem(item: EmojiCategory(name: "🍕 Pizza")),
+                OutlineItem(item: EmojiCategory(name: "🍔 Burger")),
+                OutlineItem(item: EmojiCategory(name: "🌮 Taco")),
+            ],
+            isExpanded: true
+        ),
+        OutlineItem(
+            item: EmojiCategory(name: "Sports"),
+            children: [
+                OutlineItem(item: EmojiCategory(name: "⚽ Soccer")),
+                OutlineItem(item: EmojiCategory(name: "🏀 Basketball")),
+                OutlineItem(item: EmojiCategory(name: "🎾 Tennis")),
+            ]
+        ),
+    ]
+
+    var body: some View {
+        OutlineListView(
+            items: items,
+            onSelect: { category in
+                print("Selected: \(category.name)")
+            },
+            contextMenuProvider: { category in
+                UIContextMenuConfiguration(actionProvider: { _ in
+                    let copy = UIAction(title: "Copy Name", image: UIImage(systemName: "doc.on.doc")) { _ in
+                        UIPasteboard.general.string = category.name
+                    }
+                    return UIMenu(children: [copy])
+                })
+            },
+            onRefresh: {
+                try? await Task.sleep(for: .seconds(1))
+                // Randomize expansion state
+                items = items.map { topLevel in
+                    OutlineItem(
+                        item: topLevel.item,
+                        children: topLevel.children.shuffled(),
+                        isExpanded: Bool.random()
+                    )
+                }
+            }
+        ) { category in
+            Text(category.name)
+                .padding(.vertical, 2)
+        }
+    }
+}
+
+// MARK: - Data Models
+
+private struct Fruit: Hashable, Identifiable, Sendable {
+    let id = UUID()
+    let name: String
+    let emoji: String
+}
+
+private struct EmojiCategory: Hashable, Identifiable, Sendable {
+    let id = UUID()
+    let name: String
+}
+
+// MARK: - Cell View Models
+
+private struct LanguageItem: SwiftUICellViewModel, Identifiable {
+    let id = UUID()
+    let name: String
+    let year: Int
+
+    var body: some View {
+        HStack {
+            Text(name)
+                .font(.body)
+            Spacer()
+            Text(String(year))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    var accessories: [ListAccessory] {
+        [.disclosureIndicator]
+    }
+}

--- a/Sources/Lists/Configurations/OutlineList.swift
+++ b/Sources/Lists/Configurations/OutlineList.swift
@@ -1,7 +1,7 @@
 import ListKit
 import UIKit
 
-public struct OutlineItem<Item: CellViewModel>: Sendable, Equatable {
+public struct OutlineItem<Item: Hashable & Sendable>: Sendable, Equatable {
     public let item: Item
     public let children: [OutlineItem<Item>]
     public let isExpanded: Bool
@@ -11,37 +11,71 @@ public struct OutlineItem<Item: CellViewModel>: Sendable, Equatable {
         self.children = children
         self.isExpanded = isExpanded
     }
+
+    /// Recursively transforms every `item` in this tree using the given closure.
+    public func mapItems<T: Hashable & Sendable>(_ transform: (Item) -> T) -> OutlineItem<T> {
+        OutlineItem<T>(
+            item: transform(item),
+            children: children.map { $0.mapItems(transform) },
+            isExpanded: isExpanded
+        )
+    }
 }
 
 @MainActor
 public final class OutlineList<Item: CellViewModel>: NSObject, UICollectionViewDelegate {
     public let collectionView: UICollectionView
     private let dataSource: ListDataSource<Int, Item>
+    private let bridge: SwipeActionBridge<Int, Item>
+    private var applyTask: Task<Void, Never>?
 
     public var onSelect: (@MainActor (Item) -> Void)?
 
+    /// Closure that returns trailing swipe actions for a given item.
+    public var trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    /// Closure that returns leading swipe actions for a given item.
+    public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    /// Closure that returns a context menu configuration for a given item.
+    public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+
     public init(appearance: UICollectionLayoutListConfiguration.Appearance = .sidebar) {
-        let config = UICollectionLayoutListConfiguration(appearance: appearance)
+        let bridge = SwipeActionBridge<Int, Item>()
+        self.bridge = bridge
+
+        var config = UICollectionLayoutListConfiguration(appearance: appearance)
+        bridge.configureSwipeActions(on: &config)
         let layout = UICollectionViewCompositionalLayout.list(using: config)
+
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         dataSource = ListDataSource(collectionView: collectionView)
         super.init()
         collectionView.delegate = self
+
+        bridge.dataSource = dataSource
+        bridge.trailingProvider = { [weak self] item in self?.trailingSwipeActionsProvider?(item) }
+        bridge.leadingProvider = { [weak self] item in self?.leadingSwipeActionsProvider?(item) }
     }
 
     public func setItems(_ items: [OutlineItem<Item>], animatingDifferences: Bool = true) async {
-        var sectionSnapshot = DiffableDataSourceSectionSnapshot<Item>()
-        appendItems(items, to: nil, in: &sectionSnapshot)
+        let previousTask = applyTask
+        let task = Task { @MainActor in
+            _ = await previousTask?.value
+            guard !Task.isCancelled else { return }
+            var sectionSnapshot = DiffableDataSourceSectionSnapshot<Item>()
+            self.appendItems(items, to: nil, in: &sectionSnapshot)
 
-        // Ensure the section exists in the main snapshot
-        let currentSnapshot = dataSource.snapshot()
-        if currentSnapshot.numberOfSections == 0 {
-            var snapshot = DiffableDataSourceSnapshot<Int, Item>()
-            snapshot.appendSections([0])
-            await dataSource.applyUsingReloadData(snapshot)
+            // Ensure the section exists in the main snapshot
+            let currentSnapshot = self.dataSource.snapshot()
+            if currentSnapshot.numberOfSections == 0 {
+                var snapshot = DiffableDataSourceSnapshot<Int, Item>()
+                snapshot.appendSections([0])
+                await self.dataSource.applyUsingReloadData(snapshot)
+            }
+
+            await self.dataSource.apply(sectionSnapshot, to: 0, animatingDifferences: animatingDifferences)
         }
-
-        await dataSource.apply(sectionSnapshot, to: 0, animatingDifferences: animatingDifferences)
+        applyTask = task
+        await task.value
     }
 
     public func snapshot() -> DiffableDataSourceSnapshot<Int, Item> {
@@ -52,8 +86,20 @@ public final class OutlineList<Item: CellViewModel>: NSObject, UICollectionViewD
 
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
-        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+        guard let item = dataSource.itemIdentifier(for: indexPath) else {
+            assertionFailure("Item not found for indexPath \(indexPath)")
+            return
+        }
         onSelect?(item)
+    }
+
+    public func collectionView(
+        _: UICollectionView,
+        contextMenuConfigurationForItemAt indexPath: IndexPath,
+        point _: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return nil }
+        return contextMenuProvider?(item)
     }
 
     // MARK: - Private

--- a/Sources/Lists/Configurations/SimpleList.swift
+++ b/Sources/Lists/Configurations/SimpleList.swift
@@ -5,23 +5,48 @@ import UIKit
 public final class SimpleList<Item: CellViewModel>: NSObject, UICollectionViewDelegate {
     public let collectionView: UICollectionView
     private let dataSource: ListDataSource<Int, Item>
+    private let bridge: SwipeActionBridge<Int, Item>
+    private var applyTask: Task<Void, Never>?
 
     public var onSelect: (@MainActor (Item) -> Void)?
 
+    /// Closure that returns trailing swipe actions for a given item.
+    public var trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    /// Closure that returns leading swipe actions for a given item.
+    public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    /// Closure that returns a context menu configuration for a given item.
+    public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+
     public init(appearance: UICollectionLayoutListConfiguration.Appearance = .plain) {
-        let config = UICollectionLayoutListConfiguration(appearance: appearance)
+        let bridge = SwipeActionBridge<Int, Item>()
+        self.bridge = bridge
+
+        var config = UICollectionLayoutListConfiguration(appearance: appearance)
+        bridge.configureSwipeActions(on: &config)
         let layout = UICollectionViewCompositionalLayout.list(using: config)
+
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         dataSource = ListDataSource(collectionView: collectionView)
         super.init()
         collectionView.delegate = self
+
+        bridge.dataSource = dataSource
+        bridge.trailingProvider = { [weak self] item in self?.trailingSwipeActionsProvider?(item) }
+        bridge.leadingProvider = { [weak self] item in self?.leadingSwipeActionsProvider?(item) }
     }
 
     public func setItems(_ items: [Item], animatingDifferences: Bool = true) async {
-        var snapshot = DiffableDataSourceSnapshot<Int, Item>()
-        snapshot.appendSections([0])
-        snapshot.appendItems(items, toSection: 0)
-        await dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
+        let previousTask = applyTask
+        let task = Task { @MainActor in
+            _ = await previousTask?.value
+            guard !Task.isCancelled else { return }
+            var snapshot = DiffableDataSourceSnapshot<Int, Item>()
+            snapshot.appendSections([0])
+            snapshot.appendItems(items, toSection: 0)
+            await self.dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
+        }
+        applyTask = task
+        await task.value
     }
 
     public func setItems(animatingDifferences: Bool = true, @ItemsBuilder<Item> content: () -> [Item]) async {
@@ -36,7 +61,19 @@ public final class SimpleList<Item: CellViewModel>: NSObject, UICollectionViewDe
 
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
-        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+        guard let item = dataSource.itemIdentifier(for: indexPath) else {
+            assertionFailure("Item not found for indexPath \(indexPath)")
+            return
+        }
         onSelect?(item)
+    }
+
+    public func collectionView(
+        _: UICollectionView,
+        contextMenuConfigurationForItemAt indexPath: IndexPath,
+        point _: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return nil }
+        return contextMenuProvider?(item)
     }
 }

--- a/Sources/Lists/Configurations/SwipeActionBridge.swift
+++ b/Sources/Lists/Configurations/SwipeActionBridge.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+/// A reference-type bridge that resolves `IndexPath` → `Item` for swipe action providers.
+///
+/// Created before `super.init()` and captured by the layout config closure. Populated
+/// with `dataSource` and provider closures after init completes. This solves Swift's
+/// strict initialization rules — the layout config needs a closure that references the
+/// data source, but the data source isn't available until after `super.init()`.
+@MainActor
+final class SwipeActionBridge<SectionID: Hashable & Sendable, Item: CellViewModel> {
+    var dataSource: ListDataSource<SectionID, Item>?
+    var trailingProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    var leadingProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+
+    func resolveTrailing(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return nil }
+        return trailingProvider?(item)
+    }
+
+    func resolveLeading(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return nil }
+        return leadingProvider?(item)
+    }
+
+    /// Configures both swipe action providers on a list layout configuration.
+    func configureSwipeActions(on config: inout UICollectionLayoutListConfiguration) {
+        config.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
+            self?.resolveTrailing(at: indexPath)
+        }
+        config.leadingSwipeActionsConfigurationProvider = { [weak self] indexPath in
+            self?.resolveLeading(at: indexPath)
+        }
+    }
+}

--- a/Sources/Lists/Extensions/RefreshControlConfiguration.swift
+++ b/Sources/Lists/Extensions/RefreshControlConfiguration.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+/// Configures a `UIRefreshControl` on a collection view when `onRefresh` is non-nil,
+/// or removes it when `onRefresh` is nil.
+@MainActor
+func configureRefreshControl(
+    on collectionView: UICollectionView,
+    onRefresh: (@MainActor () async -> Void)?,
+    target: AnyObject,
+    action: Selector
+) {
+    if onRefresh != nil, collectionView.refreshControl == nil {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(target, action: action, for: .valueChanged)
+        collectionView.refreshControl = refreshControl
+    } else if onRefresh == nil {
+        collectionView.refreshControl = nil
+    }
+}

--- a/Sources/Lists/SwiftUI/GroupedListView.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView.swift
@@ -6,31 +6,67 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
     public let sections: [SectionModel<SectionID, Item>]
     public let appearance: UICollectionLayoutListConfiguration.Appearance
     public var onSelect: (@MainActor (Item) -> Void)?
+    public var trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+    public var onRefresh: (@MainActor () async -> Void)?
 
     public init(
         sections: [SectionModel<SectionID, Item>],
         appearance: UICollectionLayoutListConfiguration.Appearance = .insetGrouped,
-        onSelect: (@MainActor (Item) -> Void)? = nil
+        onSelect: (@MainActor (Item) -> Void)? = nil,
+        trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
+        leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
+        contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)? = nil,
+        onRefresh: (@MainActor () async -> Void)? = nil
     ) {
         self.sections = sections
         self.appearance = appearance
         self.onSelect = onSelect
+        self.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        self.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        self.contextMenuProvider = contextMenuProvider
+        self.onRefresh = onRefresh
     }
 
     public func makeUIView(context: Context) -> UICollectionView {
         let list = GroupedList<SectionID, Item>(appearance: appearance)
         list.onSelect = onSelect
+        list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        list.contextMenuProvider = contextMenuProvider
         context.coordinator.list = list
         context.coordinator.previousSections = sections
-        Task {
+        context.coordinator.onRefresh = onRefresh
+
+        configureRefreshControl(
+            on: list.collectionView,
+            onRefresh: onRefresh,
+            target: context.coordinator,
+            action: #selector(Coordinator.handleRefresh(_:))
+        )
+
+        context.coordinator.updateTask = Task {
             await list.setSections(sections, animatingDifferences: false)
         }
         return list.collectionView
     }
 
-    public func updateUIView(_: UICollectionView, context: Context) {
+    public func updateUIView(_ collectionView: UICollectionView, context: Context) {
         guard let list = context.coordinator.list else { return }
         list.onSelect = onSelect
+        list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        list.contextMenuProvider = contextMenuProvider
+        context.coordinator.onRefresh = onRefresh
+
+        configureRefreshControl(
+            on: collectionView,
+            onRefresh: onRefresh,
+            target: context.coordinator,
+            action: #selector(Coordinator.handleRefresh(_:))
+        )
+
         guard sections != context.coordinator.previousSections else { return }
         context.coordinator.previousSections = sections
         context.coordinator.updateTask?.cancel()
@@ -48,5 +84,62 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
         var list: GroupedList<SectionID, Item>?
         var previousSections: [SectionModel<SectionID, Item>]?
         var updateTask: Task<Void, Never>?
+        var onRefresh: (@MainActor () async -> Void)?
+        private var refreshTask: Task<Void, Never>?
+
+        deinit {
+            updateTask?.cancel()
+            refreshTask?.cancel()
+        }
+
+        @objc func handleRefresh(_ sender: UIRefreshControl) {
+            guard refreshTask == nil else { return }
+            refreshTask = Task { @MainActor in
+                await onRefresh?()
+                sender.endRefreshing()
+                refreshTask = nil
+            }
+        }
+    }
+}
+
+// MARK: - Inline Content Convenience
+
+public extension GroupedListView {
+    init<Data: Hashable & Sendable>(
+        sections: [SectionModel<SectionID, Data>],
+        appearance: UICollectionLayoutListConfiguration.Appearance = .insetGrouped,
+        accessories: [ListAccessory] = [],
+        onSelect: (@MainActor (Data) -> Void)? = nil,
+        trailingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
+        leadingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
+        contextMenuProvider: (@MainActor (Data) -> UIContextMenuConfiguration?)? = nil,
+        onRefresh: (@MainActor () async -> Void)? = nil,
+        @ViewBuilder content: @escaping @MainActor (Data) -> some View
+    ) where Item == InlineCellViewModel<Data> {
+        let mapped: [SectionModel<SectionID, InlineCellViewModel<Data>>] = sections.map { section in
+            SectionModel(
+                id: section.id,
+                items: section.items.map { InlineCellViewModel(data: $0, accessories: accessories, content: content) },
+                header: section.header,
+                footer: section.footer
+            )
+        }
+        self.sections = mapped
+        self.appearance = appearance
+        self.onRefresh = onRefresh
+
+        if let onSelect {
+            self.onSelect = { item in onSelect(item.data) }
+        }
+        if let trailingSwipeActionsProvider {
+            self.trailingSwipeActionsProvider = { item in trailingSwipeActionsProvider(item.data) }
+        }
+        if let leadingSwipeActionsProvider {
+            self.leadingSwipeActionsProvider = { item in leadingSwipeActionsProvider(item.data) }
+        }
+        if let contextMenuProvider {
+            self.contextMenuProvider = { item in contextMenuProvider(item.data) }
+        }
     }
 }

--- a/Sources/Lists/SwiftUI/InlineCellViewModel.swift
+++ b/Sources/Lists/SwiftUI/InlineCellViewModel.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import UIKit
+
+/// A type-erased `CellViewModel` that stores a data value and a `@ViewBuilder` closure.
+///
+/// Used internally by the inline-content convenience initializers on `SimpleListView`,
+/// `GroupedListView`, and `OutlineListView`. `Hashable`/`Equatable` is based on `data`
+/// and `accessories` — the content closure is not compared.
+public struct InlineCellViewModel<Data: Hashable & Sendable>: CellViewModel, Identifiable {
+    public typealias Cell = UICollectionViewListCell
+
+    public let data: Data
+
+    public var id: Data {
+        data
+    }
+
+    private let content: @MainActor (Data) -> AnyView
+    private let accessories: [ListAccessory]
+
+    public init(
+        data: Data,
+        accessories: [ListAccessory] = [],
+        @ViewBuilder content: @escaping @MainActor (Data) -> some View
+    ) {
+        self.data = data
+        self.accessories = accessories
+        self.content = { data in AnyView(content(data)) }
+    }
+
+    @MainActor
+    public func configure(_ cell: UICollectionViewListCell) {
+        cell.contentConfiguration = UIHostingConfiguration {
+            content(data)
+        }
+        cell.accessories = accessories.map(\.uiAccessory)
+    }
+
+    public static func == (lhs: InlineCellViewModel, rhs: InlineCellViewModel) -> Bool {
+        lhs.data == rhs.data && lhs.accessories == rhs.accessories
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(data)
+        hasher.combine(accessories)
+    }
+}

--- a/Sources/Lists/SwiftUI/ListAccessory.swift
+++ b/Sources/Lists/SwiftUI/ListAccessory.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+/// A pure-Swift cell accessory type that replaces `UICellAccessory` in SwiftUI cell view models.
+///
+/// Use this instead of importing UIKit's `UICellAccessory` directly. The `.custom()` case
+/// provides an escape hatch for advanced accessories not covered by the convenience cases.
+///
+/// - Note: This type is `@unchecked Sendable` because the `.custom` case holds a
+///   `UICellAccessory`, which is not `Sendable`. All `ListAccessory` values must be
+///   created and accessed on `@MainActor`.
+public enum ListAccessory: @unchecked Sendable, Hashable {
+    case disclosureIndicator
+    case checkmark
+    case delete
+    case reorder
+    case outlineDisclosure
+    case detail
+
+    /// Escape hatch for parameterized accessories (e.g., `UICellAccessory.detail(actionHandler:)`).
+    /// The `key` is used for equality — two `.custom` values are equal when their keys match.
+    case custom(UICellAccessory, key: AnyHashable)
+
+    public static func == (lhs: ListAccessory, rhs: ListAccessory) -> Bool {
+        switch (lhs, rhs) {
+        case (.disclosureIndicator, .disclosureIndicator),
+             (.checkmark, .checkmark),
+             (.delete, .delete),
+             (.reorder, .reorder),
+             (.outlineDisclosure, .outlineDisclosure),
+             (.detail, .detail):
+            true
+        case let (.custom(_, lhsKey), .custom(_, rhsKey)):
+            lhsKey == rhsKey
+        default:
+            false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .disclosureIndicator: hasher.combine(0)
+        case .checkmark: hasher.combine(1)
+        case .delete: hasher.combine(2)
+        case .reorder: hasher.combine(3)
+        case .outlineDisclosure: hasher.combine(4)
+        case .detail: hasher.combine(5)
+        case let .custom(_, key): hasher.combine(6); hasher.combine(key)
+        }
+    }
+
+    /// Converts to the UIKit `UICellAccessory` equivalent.
+    public var uiAccessory: UICellAccessory {
+        switch self {
+        case .disclosureIndicator: .disclosureIndicator()
+        case .checkmark: .checkmark()
+        case .delete: .delete()
+        case .reorder: .reorder()
+        case .outlineDisclosure: .outlineDisclosure()
+        case .detail: .detail()
+        case let .custom(accessory, _): accessory
+        }
+    }
+}

--- a/Sources/Lists/SwiftUI/OutlineListView.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView.swift
@@ -6,31 +6,67 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
     public let items: [OutlineItem<Item>]
     public let appearance: UICollectionLayoutListConfiguration.Appearance
     public var onSelect: (@MainActor (Item) -> Void)?
+    public var trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+    public var onRefresh: (@MainActor () async -> Void)?
 
     public init(
         items: [OutlineItem<Item>],
         appearance: UICollectionLayoutListConfiguration.Appearance = .sidebar,
-        onSelect: (@MainActor (Item) -> Void)? = nil
+        onSelect: (@MainActor (Item) -> Void)? = nil,
+        trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
+        leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
+        contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)? = nil,
+        onRefresh: (@MainActor () async -> Void)? = nil
     ) {
         self.items = items
         self.appearance = appearance
         self.onSelect = onSelect
+        self.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        self.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        self.contextMenuProvider = contextMenuProvider
+        self.onRefresh = onRefresh
     }
 
     public func makeUIView(context: Context) -> UICollectionView {
         let list = OutlineList<Item>(appearance: appearance)
         list.onSelect = onSelect
+        list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        list.contextMenuProvider = contextMenuProvider
         context.coordinator.list = list
         context.coordinator.previousItems = items
-        Task {
+        context.coordinator.onRefresh = onRefresh
+
+        configureRefreshControl(
+            on: list.collectionView,
+            onRefresh: onRefresh,
+            target: context.coordinator,
+            action: #selector(Coordinator.handleRefresh(_:))
+        )
+
+        context.coordinator.updateTask = Task {
             await list.setItems(items, animatingDifferences: false)
         }
         return list.collectionView
     }
 
-    public func updateUIView(_: UICollectionView, context: Context) {
+    public func updateUIView(_ collectionView: UICollectionView, context: Context) {
         guard let list = context.coordinator.list else { return }
         list.onSelect = onSelect
+        list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        list.contextMenuProvider = contextMenuProvider
+        context.coordinator.onRefresh = onRefresh
+
+        configureRefreshControl(
+            on: collectionView,
+            onRefresh: onRefresh,
+            target: context.coordinator,
+            action: #selector(Coordinator.handleRefresh(_:))
+        )
+
         guard items != context.coordinator.previousItems else { return }
         context.coordinator.previousItems = items
         context.coordinator.updateTask?.cancel()
@@ -48,5 +84,56 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
         var list: OutlineList<Item>?
         var previousItems: [OutlineItem<Item>]?
         var updateTask: Task<Void, Never>?
+        var onRefresh: (@MainActor () async -> Void)?
+        private var refreshTask: Task<Void, Never>?
+
+        deinit {
+            updateTask?.cancel()
+            refreshTask?.cancel()
+        }
+
+        @objc func handleRefresh(_ sender: UIRefreshControl) {
+            guard refreshTask == nil else { return }
+            refreshTask = Task { @MainActor in
+                await onRefresh?()
+                sender.endRefreshing()
+                refreshTask = nil
+            }
+        }
+    }
+}
+
+// MARK: - Inline Content Convenience
+
+public extension OutlineListView {
+    init<Data: Hashable & Sendable>(
+        items: [OutlineItem<Data>],
+        appearance: UICollectionLayoutListConfiguration.Appearance = .sidebar,
+        accessories: [ListAccessory] = [],
+        onSelect: (@MainActor (Data) -> Void)? = nil,
+        trailingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
+        leadingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
+        contextMenuProvider: (@MainActor (Data) -> UIContextMenuConfiguration?)? = nil,
+        onRefresh: (@MainActor () async -> Void)? = nil,
+        @ViewBuilder content: @escaping @MainActor (Data) -> some View
+    ) where Item == InlineCellViewModel<Data> {
+        let mapped = items.map { $0.mapItems { InlineCellViewModel(data: $0, accessories: accessories, content: content) } }
+
+        self.items = mapped
+        self.appearance = appearance
+        self.onRefresh = onRefresh
+
+        if let onSelect {
+            self.onSelect = { item in onSelect(item.data) }
+        }
+        if let trailingSwipeActionsProvider {
+            self.trailingSwipeActionsProvider = { item in trailingSwipeActionsProvider(item.data) }
+        }
+        if let leadingSwipeActionsProvider {
+            self.leadingSwipeActionsProvider = { item in leadingSwipeActionsProvider(item.data) }
+        }
+        if let contextMenuProvider {
+            self.contextMenuProvider = { item in contextMenuProvider(item.data) }
+        }
     }
 }

--- a/Sources/Lists/SwiftUI/SimpleListView.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView.swift
@@ -6,31 +6,67 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
     public let items: [Item]
     public let appearance: UICollectionLayoutListConfiguration.Appearance
     public var onSelect: (@MainActor (Item) -> Void)?
+    public var trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
+    public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+    public var onRefresh: (@MainActor () async -> Void)?
 
     public init(
         items: [Item],
         appearance: UICollectionLayoutListConfiguration.Appearance = .plain,
-        onSelect: (@MainActor (Item) -> Void)? = nil
+        onSelect: (@MainActor (Item) -> Void)? = nil,
+        trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
+        leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
+        contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)? = nil,
+        onRefresh: (@MainActor () async -> Void)? = nil
     ) {
         self.items = items
         self.appearance = appearance
         self.onSelect = onSelect
+        self.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        self.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        self.contextMenuProvider = contextMenuProvider
+        self.onRefresh = onRefresh
     }
 
     public func makeUIView(context: Context) -> UICollectionView {
         let list = SimpleList<Item>(appearance: appearance)
         list.onSelect = onSelect
+        list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        list.contextMenuProvider = contextMenuProvider
         context.coordinator.list = list
         context.coordinator.previousItems = items
-        Task {
+        context.coordinator.onRefresh = onRefresh
+
+        configureRefreshControl(
+            on: list.collectionView,
+            onRefresh: onRefresh,
+            target: context.coordinator,
+            action: #selector(Coordinator.handleRefresh(_:))
+        )
+
+        context.coordinator.updateTask = Task {
             await list.setItems(items, animatingDifferences: false)
         }
         return list.collectionView
     }
 
-    public func updateUIView(_: UICollectionView, context: Context) {
+    public func updateUIView(_ collectionView: UICollectionView, context: Context) {
         guard let list = context.coordinator.list else { return }
         list.onSelect = onSelect
+        list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
+        list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
+        list.contextMenuProvider = contextMenuProvider
+        context.coordinator.onRefresh = onRefresh
+
+        configureRefreshControl(
+            on: collectionView,
+            onRefresh: onRefresh,
+            target: context.coordinator,
+            action: #selector(Coordinator.handleRefresh(_:))
+        )
+
         guard items != context.coordinator.previousItems else { return }
         context.coordinator.previousItems = items
         context.coordinator.updateTask?.cancel()
@@ -48,5 +84,56 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
         var list: SimpleList<Item>?
         var previousItems: [Item]?
         var updateTask: Task<Void, Never>?
+        var onRefresh: (@MainActor () async -> Void)?
+        private var refreshTask: Task<Void, Never>?
+
+        deinit {
+            updateTask?.cancel()
+            refreshTask?.cancel()
+        }
+
+        @objc func handleRefresh(_ sender: UIRefreshControl) {
+            guard refreshTask == nil else { return }
+            refreshTask = Task { @MainActor in
+                await onRefresh?()
+                sender.endRefreshing()
+                refreshTask = nil
+            }
+        }
+    }
+}
+
+// MARK: - Inline Content Convenience
+
+public extension SimpleListView {
+    init<Data: Hashable & Sendable>(
+        items: [Data],
+        appearance: UICollectionLayoutListConfiguration.Appearance = .plain,
+        accessories: [ListAccessory] = [],
+        onSelect: (@MainActor (Data) -> Void)? = nil,
+        trailingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
+        leadingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
+        contextMenuProvider: (@MainActor (Data) -> UIContextMenuConfiguration?)? = nil,
+        onRefresh: (@MainActor () async -> Void)? = nil,
+        @ViewBuilder content: @escaping @MainActor (Data) -> some View
+    ) where Item == InlineCellViewModel<Data> {
+        let mapped = items.map { InlineCellViewModel(data: $0, accessories: accessories, content: content) }
+
+        self.items = mapped
+        self.appearance = appearance
+        self.onRefresh = onRefresh
+
+        if let onSelect {
+            self.onSelect = { item in onSelect(item.data) }
+        }
+        if let trailingSwipeActionsProvider {
+            self.trailingSwipeActionsProvider = { item in trailingSwipeActionsProvider(item.data) }
+        }
+        if let leadingSwipeActionsProvider {
+            self.leadingSwipeActionsProvider = { item in leadingSwipeActionsProvider(item.data) }
+        }
+        if let contextMenuProvider {
+            self.contextMenuProvider = { item in contextMenuProvider(item.data) }
+        }
     }
 }

--- a/Sources/Lists/SwiftUI/SwiftUICellViewModel.swift
+++ b/Sources/Lists/SwiftUI/SwiftUICellViewModel.swift
@@ -12,16 +12,16 @@ import UIKit
 public protocol SwiftUICellViewModel: CellViewModel where Cell == UICollectionViewListCell {
     associatedtype Content: View
     @MainActor var body: Content { get }
-    @MainActor var accessories: [UICellAccessory] { get }
+    @MainActor var accessories: [ListAccessory] { get }
 }
 
 public extension SwiftUICellViewModel {
-    @MainActor var accessories: [UICellAccessory] {
+    @MainActor var accessories: [ListAccessory] {
         []
     }
 
     @MainActor func configure(_ cell: UICollectionViewListCell) {
         cell.contentConfiguration = UIHostingConfiguration { body }
-        cell.accessories = accessories
+        cell.accessories = accessories.map(\.uiAccessory)
     }
 }


### PR DESCRIPTION
## Summary

- Adds swipe actions (leading + trailing), context menus, and pull-to-refresh across all three list types (`SimpleList`, `GroupedList`, `OutlineList`) and their SwiftUI wrappers
- Introduces `ListAccessory` enum abstracting `UICellAccessory` for SwiftUI consumers, with `.custom` escape hatch for advanced use
- Adds `InlineCellViewModel` and `@ViewBuilder` convenience initializers so SwiftUI consumers can define cell content inline without creating dedicated `CellViewModel` types
- Introduces `SwipeActionBridge` to solve Swift's strict init ordering for layout config closures that need data source access
- Adds `RefreshControlConfiguration` shared utility for pull-to-refresh lifecycle
- Broadens `OutlineItem` generic constraint from `CellViewModel` to `Hashable & Sendable` with `mapItems` recursive transformation
- Adds Coordinator `deinit` task cleanup, atomic dictionary updates in `GroupedList`, and accessories-aware equality in `InlineCellViewModel`

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes (73/73 tests)
- [x] Pre-commit hooks (SwiftFormat + lint) pass
- [ ] Manual verification of swipe actions, context menus, and pull-to-refresh in example app
- [ ] Verify inline content convenience API renders correctly for all three list types
- [ ] Test rapid navigation to/from list views to verify Coordinator deinit cleanup