### PR TITLE
Link documentation site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A fast, pure-Swift diffable data source for `UICollectionView`. Drop-in replacem
 | **ListKit** | Low-level diffing engine and data source. API-compatible with Apple's `NSDiffableDataSourceSnapshot`. |
 | **Lists** | High-level, ViewModel-driven layer with result-builder DSL, automatic cell registration, pre-built list configurations, and SwiftUI wrappers. |
 
+**[Documentation](https://iron-ham.github.io/Lists/documentation)**
+
 ## Requirements
 
 - iOS 17.0+


### PR DESCRIPTION
## Summary
- Adds a prominent link to the [documentation site](https://iron-ham.github.io/Lists/documentation) in the README, placed after the library table for easy discoverability.

## Test plan
- [ ] Verify the documentation link renders correctly in the README
- [ ] Verify the link resolves to the GitHub Pages documentation site