### PR TITLE
Resolve crash potential and instabilities in Lists module

### DIFF
--- a/Sources/Lists/Builder/ItemsBuilder.swift
+++ b/Sources/Lists/Builder/ItemsBuilder.swift
@@ -31,4 +31,8 @@ public struct ItemsBuilder<Item: CellViewModel> {
   public static func buildArray(_ components: [[Item]]) -> [Item] {
     components.flatMap(\.self)
   }
+
+  public static func buildLimitedAvailability(_ component: [Item]) -> [Item] {
+    component
+  }
 }

--- a/Sources/Lists/Builder/MixedSnapshotBuilder.swift
+++ b/Sources/Lists/Builder/MixedSnapshotBuilder.swift
@@ -60,6 +60,10 @@ public struct MixedItemsBuilder {
   public static func buildArray(_ components: [[AnyItem]]) -> [AnyItem] {
     components.flatMap(\.self)
   }
+
+  public static func buildLimitedAvailability(_ component: [AnyItem]) -> [AnyItem] {
+    component
+  }
 }
 
 // MARK: - MixedSnapshotBuilder
@@ -89,5 +93,9 @@ public struct MixedSnapshotBuilder<SectionID: Hashable & Sendable> {
 
   public static func buildArray(_ components: [[MixedSection<SectionID>]]) -> [MixedSection<SectionID>] {
     components.flatMap(\.self)
+  }
+
+  public static func buildLimitedAvailability(_ component: [MixedSection<SectionID>]) -> [MixedSection<SectionID>] {
+    component
   }
 }

--- a/Sources/Lists/Builder/SnapshotBuilder.swift
+++ b/Sources/Lists/Builder/SnapshotBuilder.swift
@@ -54,4 +54,11 @@ public struct SnapshotBuilder<SectionID: Hashable & Sendable, Item: CellViewMode
   public static func buildArray(_ components: [[SnapshotSection<SectionID, Item>]]) -> [SnapshotSection<SectionID, Item>] {
     components.flatMap(\.self)
   }
+
+  public static func buildLimitedAvailability(_ component: [SnapshotSection<SectionID, Item>]) -> [SnapshotSection<
+    SectionID,
+    Item
+  >] {
+    component
+  }
 }

--- a/Sources/Lists/Mixed/AnyItem.swift
+++ b/Sources/Lists/Mixed/AnyItem.swift
@@ -86,9 +86,11 @@ final class DynamicCellRegistrar {
       withReuseIdentifier: String(reflecting: T.Cell.self),
       for: indexPath
     )
-    if let typedCell = cell as? T.Cell {
-      item.configure(typedCell)
+    guard let typedCell = cell as? T.Cell else {
+      assertionFailure("Dequeued cell \(type(of: cell)) is not \(T.Cell.self) — cell registration mismatch")
+      return cell
     }
+    item.configure(typedCell)
     return cell
   }
 

--- a/Tests/ListsTests/GroupedListTests.swift
+++ b/Tests/ListsTests/GroupedListTests.swift
@@ -71,4 +71,40 @@ struct GroupedListTests {
 
     #expect(list.snapshot().numberOfSections == 2)
   }
+
+  @Test
+  func rapidSectionReplacementProducesCorrectFinalState() async {
+    let list = GroupedList<String, TextItem>()
+
+    async let _ = list.setSections([
+      SectionModel(id: "A", items: [TextItem(text: "1")])
+    ], animatingDifferences: false)
+
+    async let _ = list.setSections([
+      SectionModel(id: "B", items: [TextItem(text: "2")])
+    ], animatingDifferences: false)
+
+    await list.setSections([
+      SectionModel(id: "X", items: [TextItem(text: "final")], header: "Final Header")
+    ], animatingDifferences: false)
+
+    let snapshot = list.snapshot()
+    #expect(snapshot.numberOfSections == 1)
+    #expect(snapshot.sectionIdentifiers == ["X"])
+    #expect(snapshot.numberOfItems == 1)
+  }
+
+  @Test
+  func clearAllSections() async {
+    let list = GroupedList<String, TextItem>()
+
+    await list.setSections([
+      SectionModel(id: "A", items: [TextItem(text: "1")], header: "H")
+    ], animatingDifferences: false)
+    #expect(list.snapshot().numberOfSections == 1)
+
+    await list.setSections([], animatingDifferences: false)
+    #expect(list.snapshot().numberOfSections == 0)
+    #expect(list.snapshot().numberOfItems == 0)
+  }
 }

--- a/Tests/ListsTests/MixedListTests.swift
+++ b/Tests/ListsTests/MixedListTests.swift
@@ -340,6 +340,33 @@ struct MixedSnapshotBuilderTests {
     #expect(section.id == "test")
     #expect(section.items.count == 2)
   }
+
+  @Test
+  func availabilityCheckInMixedItems() {
+    @MixedItemsBuilder
+    var items: [AnyItem] {
+      AlphaItem(value: "always")
+      if #available(iOS 17, *) {
+        BetaItem(number: 42)
+      }
+    }
+    #expect(items.count == 2)
+  }
+
+  @Test
+  func availabilityCheckInMixedSections() {
+    let snapshot = DiffableDataSourceSnapshot<String, AnyItem> {
+      MixedSection("main") {
+        AlphaItem(value: "a")
+      }
+      if #available(iOS 17, *) {
+        MixedSection("conditional") {
+          BetaItem(number: 1)
+        }
+      }
+    }
+    #expect(snapshot.numberOfSections == 2)
+  }
 }
 
 // MARK: - MixedSnapshotDiffingTests

--- a/Tests/ListsTests/OutlineListTests.swift
+++ b/Tests/ListsTests/OutlineListTests.swift
@@ -55,4 +55,57 @@ struct OutlineListTests {
     let list = OutlineList<TextItem>(appearance: .plain)
     #expect(list.collectionView.collectionViewLayout is UICollectionViewCompositionalLayout)
   }
+
+  @Test
+  func setItemsThenSetAgainUpdatesCorrectly() async {
+    let list = OutlineList<TextItem>()
+
+    // First call creates the section and populates items
+    let items1 = [
+      OutlineItem(item: TextItem(text: "A")),
+      OutlineItem(item: TextItem(text: "B")),
+    ]
+    await list.setItems(items1, animatingDifferences: false)
+    #expect(list.snapshot().numberOfItems == 2)
+
+    // Second call should update items without crashing (section already exists)
+    let items2 = [
+      OutlineItem(item: TextItem(text: "C"))
+    ]
+    await list.setItems(items2, animatingDifferences: false)
+    #expect(list.snapshot().numberOfItems == 1)
+  }
+
+  @Test
+  func setEmptyItemsThenPopulate() async {
+    let list = OutlineList<TextItem>()
+
+    // Start with empty
+    await list.setItems([], animatingDifferences: false)
+    #expect(list.snapshot().numberOfItems == 0)
+
+    // Then populate
+    let items = [
+      OutlineItem(item: TextItem(text: "A"))
+    ]
+    await list.setItems(items, animatingDifferences: false)
+    #expect(list.snapshot().numberOfItems == 1)
+  }
+
+  @Test
+  func cancelledSetItemsDoesNotCrash() async {
+    let list = OutlineList<TextItem>()
+
+    await list.setItems([OutlineItem(item: TextItem(text: "A"))], animatingDifferences: false)
+
+    let task = Task {
+      await list.setItems([OutlineItem(item: TextItem(text: "B"))], animatingDifferences: false)
+    }
+    task.cancel()
+    await task.value
+
+    // Should be in a consistent state
+    let snapshot = list.snapshot()
+    #expect(snapshot.numberOfSections <= 1)
+  }
 }

--- a/Tests/ListsTests/SnapshotBuilderTests.swift
+++ b/Tests/ListsTests/SnapshotBuilderTests.swift
@@ -171,4 +171,34 @@ struct SnapshotBuilderTests {
 
     #expect(snapshot.itemIdentifiers == [NumberItem(value: 100)])
   }
+
+  @Test
+  func availabilityCheckInItems() {
+    let snapshot = DiffableDataSourceSnapshot<String, NumberItem> {
+      SnapshotSection("main") {
+        NumberItem(value: 1)
+        if #available(iOS 17, *) {
+          NumberItem(value: 2)
+        }
+      }
+    }
+
+    #expect(snapshot.numberOfItems == 2)
+  }
+
+  @Test
+  func availabilityCheckInSections() {
+    let snapshot = DiffableDataSourceSnapshot<String, NumberItem> {
+      SnapshotSection("always") {
+        NumberItem(value: 1)
+      }
+      if #available(iOS 17, *) {
+        SnapshotSection("conditional") {
+          NumberItem(value: 2)
+        }
+      }
+    }
+
+    #expect(snapshot.numberOfSections == 2)
+  }
 }


### PR DESCRIPTION
## Summary

- **Serialize `applySnapshotUsingReloadData` with the `apply()` task chain** to prevent snapshot/UI mismatches when both are in flight concurrently
- **Add cooperative cancellation** to all list `setItems`/`setSections` methods — stale queued applies are cancelled when a newer update arrives, and cancellation propagates from the calling task via `withTaskCancellationHandler`
- **Fix snapshot update ordering** in `performApply`: `currentSnapshot` is now updated *before* computing the diff so `cellForItemAt` always reads the new snapshot, eliminating index-out-of-bounds crashes
- **Add `buildLimitedAvailability`** to all result builders (`ItemsBuilder`, `SnapshotBuilder`, `MixedItemsBuilder`, `MixedSnapshotBuilder`) so `#available` checks compile inside builder DSLs
- **Harden `cellForItemAt` and `DynamicCellRegistrar`** with `assertionFailure` guards for easier debugging when snapshot/UI state diverges
- **Fix GroupedList header/footer handling** during animations — headers are merged before apply and trimmed after, preventing missing headers during animated transitions
- **Rewrite OutlineList `setItems`** to use a single main-snapshot apply instead of two sequential applies (`applyUsingReloadData` + section snapshot), avoiding a race where the second apply could act on stale state

## Test plan

- [x] `DataSourceLifecycleTests.reloadDataSerializesWithApply` — interleaved `apply`/`reloadData` stays ordered
- [x] `DataSourceLifecycleTests.cancelledApplyIsSkipped` — cancelled task doesn't corrupt snapshot
- [x] `GroupedListTests.rapidSectionReplacementProducesCorrectFinalState` — rapid section swaps converge
- [x] `GroupedListTests.clearAllSections` — empty section array clears state
- [x] `SimpleListTests.cancelledSetItemsDoesNotCrash` — cancellation leaves consistent state
- [x] `SimpleListTests.rapidSetItemsConverges` — burst of updates converges to final state
- [x] `OutlineListTests.setItemsThenSetAgainUpdatesCorrectly` — second `setItems` correctly replaces first
- [x] `OutlineListTests.setEmptyItemsThenPopulate` — empty-then-populate lifecycle works
- [x] `OutlineListTests.cancelledSetItemsDoesNotCrash` — cancellation leaves consistent state
- [x] `SnapshotBuilderTests.availabilityCheckInItems/Sections` — `#available` compiles in builders
- [x] `MixedSnapshotBuilderTests.availabilityCheckInMixedItems/Sections` — `#available` compiles in mixed builders
- [x] Updated `applyWithNilCollectionView` to reflect new snapshot-always-updates behavior