### PR TITLE
fix: address deep review findings across safety, API completeness, an…

### DIFF
--- a/Sources/ListKit/DataSource/CollectionViewDiffableDataSource.swift
+++ b/Sources/ListKit/DataSource/CollectionViewDiffableDataSource.swift
@@ -188,12 +188,19 @@ public final class CollectionViewDiffableDataSource<
     moveItemAt sourceIndexPath: IndexPath,
     to destinationIndexPath: IndexPath
   ) {
-    guard let item = itemIdentifier(for: sourceIndexPath) else { return }
+    guard let item = itemIdentifier(for: sourceIndexPath) else {
+      assertionFailure("Move failed: no item at source \(sourceIndexPath)")
+      return
+    }
 
     // Remove the item from its current position in the snapshot
     currentSnapshot.deleteItems([item])
 
     // Insert at the destination
+    guard destinationIndexPath.section < currentSnapshot.sectionIdentifiers.count else {
+      assertionFailure("Move failed: destination section \(destinationIndexPath.section) out of bounds")
+      return
+    }
     let destSectionID = currentSnapshot.sectionIdentifiers[destinationIndexPath.section]
     let destItems = currentSnapshot.itemIdentifiers(inSection: destSectionID)
 
@@ -216,6 +223,10 @@ public final class CollectionViewDiffableDataSource<
     }
     // UICollectionView requires supplementary views to be dequeued via a registration.
     // Lazily create a fallback registration per element kind that returns an empty view.
+    assert(
+      fallbackRegistrations.count < 10,
+      "Excessive supplementary element kinds (\(fallbackRegistrations.count)). Verify element kinds are not dynamically generated."
+    )
     if fallbackRegistrations[kind] == nil {
       fallbackRegistrations[kind] = UICollectionView.SupplementaryRegistration<UICollectionReusableView>(
         elementKind: kind

--- a/Sources/ListKit/Snapshot/DiffableDataSourceSectionSnapshot.swift
+++ b/Sources/ListKit/Snapshot/DiffableDataSourceSectionSnapshot.swift
@@ -176,12 +176,13 @@ public struct DiffableDataSourceSectionSnapshot<ItemIdentifierType: Hashable & S
     // Copy relevant maps — only include references to items present in the new snapshot.
     // Without the containment check, a `snapshot(of: child, includingParent: true)` call
     // would copy the child's grandparent reference, creating a dangling parent entry.
+    let snapshotItemSet = newSnapshot.itemSet
     for snapshotItem in newSnapshot.items {
-      if let parent = parentMap[snapshotItem], newSnapshot.itemSet.contains(parent) {
+      if let parent = parentMap[snapshotItem], snapshotItemSet.contains(parent) {
         newSnapshot.parentMap[snapshotItem] = parent
       }
       if let children = childrenMap[snapshotItem] {
-        newSnapshot.childrenMap[snapshotItem] = children.filter { newSnapshot.itemSet.contains($0) }
+        newSnapshot.childrenMap[snapshotItem] = children.filter { snapshotItemSet.contains($0) }
       }
       if expandedItems.contains(snapshotItem) {
         newSnapshot.expandedItems.insert(snapshotItem)

--- a/Sources/Lists/Configurations/SimpleList.swift
+++ b/Sources/Lists/Configurations/SimpleList.swift
@@ -35,6 +35,7 @@ public final class SimpleList<Item: CellViewModel>: NSObject, UICollectionViewDe
     collectionView.delegate = self
 
     bridge.dataSource = dataSource
+    // trailingSwipeActionsProvider takes precedence; onDelete is the fallback.
     bridge.trailingProvider = { [weak self] item in
       guard let self else { return nil }
       if let config = trailingSwipeActionsProvider?(item) {
@@ -61,6 +62,9 @@ public final class SimpleList<Item: CellViewModel>: NSObject, UICollectionViewDe
 
   /// Called when the user swipe-deletes an item. When set and ``trailingSwipeActionsProvider``
   /// is `nil`, a trailing destructive "Delete" swipe action is provided automatically.
+  ///
+  /// - Important: The caller is responsible for removing the item from the data source
+  ///   after this callback fires. The list does not automatically mutate its snapshot.
   public var onDelete: (@MainActor (Item) -> Void)?
 
   /// Closure that returns trailing swipe actions for a given item.
@@ -122,7 +126,10 @@ public final class SimpleList<Item: CellViewModel>: NSObject, UICollectionViewDe
   }
 
   public func collectionView(_: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-    guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+    guard let item = dataSource.itemIdentifier(for: indexPath) else {
+      assertionFailure("Item not found for indexPath \(indexPath)")
+      return
+    }
     onDeselect?(item)
   }
 

--- a/Sources/Lists/Extensions/LayoutHelpers.swift
+++ b/Sources/Lists/Extensions/LayoutHelpers.swift
@@ -7,17 +7,16 @@ import UIKit
 /// their own layouts automatically.
 @MainActor
 public enum ListLayout {
+
+  // MARK: Public
+
   /// Creates a plain list layout with optional header and footer modes.
   public static func plain(
     headerMode: UICollectionLayoutListConfiguration.HeaderMode = .none,
     footerMode: UICollectionLayoutListConfiguration.FooterMode = .none,
     showsSeparators: Bool = true
   ) -> UICollectionViewCompositionalLayout {
-    var config = UICollectionLayoutListConfiguration(appearance: .plain)
-    config.headerMode = headerMode
-    config.footerMode = footerMode
-    config.showsSeparators = showsSeparators
-    return UICollectionViewCompositionalLayout.list(using: config)
+    makeLayout(appearance: .plain, headerMode: headerMode, footerMode: footerMode, showsSeparators: showsSeparators)
   }
 
   /// Creates an inset-grouped list layout with optional header and footer modes.
@@ -26,11 +25,7 @@ public enum ListLayout {
     footerMode: UICollectionLayoutListConfiguration.FooterMode = .none,
     showsSeparators: Bool = true
   ) -> UICollectionViewCompositionalLayout {
-    var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
-    config.headerMode = headerMode
-    config.footerMode = footerMode
-    config.showsSeparators = showsSeparators
-    return UICollectionViewCompositionalLayout.list(using: config)
+    makeLayout(appearance: .insetGrouped, headerMode: headerMode, footerMode: footerMode, showsSeparators: showsSeparators)
   }
 
   /// Creates a sidebar list layout with optional header and footer modes.
@@ -39,7 +34,18 @@ public enum ListLayout {
     footerMode: UICollectionLayoutListConfiguration.FooterMode = .none,
     showsSeparators: Bool = true
   ) -> UICollectionViewCompositionalLayout {
-    var config = UICollectionLayoutListConfiguration(appearance: .sidebar)
+    makeLayout(appearance: .sidebar, headerMode: headerMode, footerMode: footerMode, showsSeparators: showsSeparators)
+  }
+
+  // MARK: Private
+
+  private static func makeLayout(
+    appearance: UICollectionLayoutListConfiguration.Appearance,
+    headerMode: UICollectionLayoutListConfiguration.HeaderMode,
+    footerMode: UICollectionLayoutListConfiguration.FooterMode,
+    showsSeparators: Bool
+  ) -> UICollectionViewCompositionalLayout {
+    var config = UICollectionLayoutListConfiguration(appearance: appearance)
     config.headerMode = headerMode
     config.footerMode = footerMode
     config.showsSeparators = showsSeparators

--- a/Sources/Lists/SwiftUI/GroupedListView.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView.swift
@@ -17,6 +17,7 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
     appearance: UICollectionLayoutListConfiguration.Appearance = .insetGrouped,
     showsSeparators: Bool = true,
     onSelect: (@MainActor (Item) -> Void)? = nil,
+    onDeselect: (@MainActor (Item) -> Void)? = nil,
     onDelete: (@MainActor (Item) -> Void)? = nil,
     trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
     leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
@@ -27,6 +28,7 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
     self.appearance = appearance
     self.showsSeparators = showsSeparators
     self.onSelect = onSelect
+    self.onDeselect = onDeselect
     self.onDelete = onDelete
     self.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     self.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -77,6 +79,8 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
   public let showsSeparators: Bool
   /// Called when the user taps an item.
   public var onSelect: (@MainActor (Item) -> Void)?
+  /// Called when the user deselects an item (relevant when `allowsMultipleSelection` is enabled).
+  public var onDeselect: (@MainActor (Item) -> Void)?
   /// Called when the user swipe-deletes an item. When set and ``trailingSwipeActionsProvider``
   /// is `nil`, a trailing destructive "Delete" swipe action is provided automatically.
   public var onDelete: (@MainActor (Item) -> Void)?
@@ -98,6 +102,7 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
   public func makeUIView(context: Context) -> UICollectionView {
     let list = GroupedList<SectionID, Item>(appearance: appearance, showsSeparators: showsSeparators)
     list.onSelect = onSelect
+    list.onDeselect = onDeselect
     list.onDelete = onDelete
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -122,6 +127,7 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
   public func updateUIView(_ collectionView: UICollectionView, context: Context) {
     guard let list = context.coordinator.list else { return }
     list.onSelect = onSelect
+    list.onDeselect = onDeselect
     list.onDelete = onDelete
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -158,6 +164,7 @@ extension GroupedListView {
     showsSeparators: Bool = true,
     accessories: [ListAccessory] = [],
     onSelect: (@MainActor (Data) -> Void)? = nil,
+    onDeselect: (@MainActor (Data) -> Void)? = nil,
     onDelete: (@MainActor (Data) -> Void)? = nil,
     trailingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
     leadingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
@@ -180,6 +187,9 @@ extension GroupedListView {
 
     if let onSelect {
       self.onSelect = { item in onSelect(item.data) }
+    }
+    if let onDeselect {
+      self.onDeselect = { item in onDeselect(item.data) }
     }
     if let onDelete {
       self.onDelete = { item in onDelete(item.data) }

--- a/Sources/Lists/SwiftUI/ListAccessory.swift
+++ b/Sources/Lists/SwiftUI/ListAccessory.swift
@@ -17,6 +17,7 @@ public enum ListAccessory: @unchecked Sendable, Hashable {
   case detail
 
   /// A text label displayed on the trailing side of the cell (e.g., a count badge).
+  /// An empty string produces a visible but blank accessory label.
   case label(text: String)
 
   /// Escape hatch for parameterized accessories (e.g., `UICellAccessory.detail(actionHandler:)`).

--- a/Sources/Lists/SwiftUI/OutlineListView.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView.swift
@@ -17,6 +17,7 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
     appearance: UICollectionLayoutListConfiguration.Appearance = .sidebar,
     showsSeparators: Bool = true,
     onSelect: (@MainActor (Item) -> Void)? = nil,
+    onDeselect: (@MainActor (Item) -> Void)? = nil,
     onDelete: (@MainActor (Item) -> Void)? = nil,
     trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
     leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
@@ -27,6 +28,7 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
     self.appearance = appearance
     self.showsSeparators = showsSeparators
     self.onSelect = onSelect
+    self.onDeselect = onDeselect
     self.onDelete = onDelete
     self.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     self.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -77,6 +79,8 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
   public let showsSeparators: Bool
   /// Called when the user taps an item.
   public var onSelect: (@MainActor (Item) -> Void)?
+  /// Called when the user deselects an item (relevant when `allowsMultipleSelection` is enabled).
+  public var onDeselect: (@MainActor (Item) -> Void)?
   /// Called when the user swipe-deletes an item. When set and ``trailingSwipeActionsProvider``
   /// is `nil`, a trailing destructive "Delete" swipe action is provided automatically.
   public var onDelete: (@MainActor (Item) -> Void)?
@@ -98,6 +102,7 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
   public func makeUIView(context: Context) -> UICollectionView {
     let list = OutlineList<Item>(appearance: appearance, showsSeparators: showsSeparators)
     list.onSelect = onSelect
+    list.onDeselect = onDeselect
     list.onDelete = onDelete
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -122,6 +127,7 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
   public func updateUIView(_ collectionView: UICollectionView, context: Context) {
     guard let list = context.coordinator.list else { return }
     list.onSelect = onSelect
+    list.onDeselect = onDeselect
     list.onDelete = onDelete
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -158,6 +164,7 @@ extension OutlineListView {
     showsSeparators: Bool = true,
     accessories: [ListAccessory] = [],
     onSelect: (@MainActor (Data) -> Void)? = nil,
+    onDeselect: (@MainActor (Data) -> Void)? = nil,
     onDelete: (@MainActor (Data) -> Void)? = nil,
     trailingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
     leadingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
@@ -174,6 +181,9 @@ extension OutlineListView {
 
     if let onSelect {
       self.onSelect = { item in onSelect(item.data) }
+    }
+    if let onDeselect {
+      self.onDeselect = { item in onDeselect(item.data) }
     }
     if let onDelete {
       self.onDelete = { item in onDelete(item.data) }

--- a/Sources/Lists/SwiftUI/SimpleListView.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView.swift
@@ -18,6 +18,7 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
     appearance: UICollectionLayoutListConfiguration.Appearance = .plain,
     showsSeparators: Bool = true,
     onSelect: (@MainActor (Item) -> Void)? = nil,
+    onDeselect: (@MainActor (Item) -> Void)? = nil,
     onDelete: (@MainActor (Item) -> Void)? = nil,
     trailingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
     leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)? = nil,
@@ -28,6 +29,7 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
     self.appearance = appearance
     self.showsSeparators = showsSeparators
     self.onSelect = onSelect
+    self.onDeselect = onDeselect
     self.onDelete = onDelete
     self.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     self.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -78,6 +80,8 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
   public let showsSeparators: Bool
   /// Called when the user taps an item.
   public var onSelect: (@MainActor (Item) -> Void)?
+  /// Called when the user deselects an item (relevant when `allowsMultipleSelection` is enabled).
+  public var onDeselect: (@MainActor (Item) -> Void)?
   /// Called when the user swipe-deletes an item. When set and ``trailingSwipeActionsProvider``
   /// is `nil`, a trailing destructive "Delete" swipe action is provided automatically.
   public var onDelete: (@MainActor (Item) -> Void)?
@@ -99,6 +103,7 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
   public func makeUIView(context: Context) -> UICollectionView {
     let list = SimpleList<Item>(appearance: appearance, showsSeparators: showsSeparators)
     list.onSelect = onSelect
+    list.onDeselect = onDeselect
     list.onDelete = onDelete
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -123,6 +128,7 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
   public func updateUIView(_ collectionView: UICollectionView, context: Context) {
     guard let list = context.coordinator.list else { return }
     list.onSelect = onSelect
+    list.onDeselect = onDeselect
     list.onDelete = onDelete
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
@@ -159,6 +165,7 @@ extension SimpleListView {
     showsSeparators: Bool = true,
     accessories: [ListAccessory] = [],
     onSelect: (@MainActor (Data) -> Void)? = nil,
+    onDeselect: (@MainActor (Data) -> Void)? = nil,
     onDelete: (@MainActor (Data) -> Void)? = nil,
     trailingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
     leadingSwipeActionsProvider: (@MainActor (Data) -> UISwipeActionsConfiguration?)? = nil,
@@ -175,6 +182,9 @@ extension SimpleListView {
 
     if let onSelect {
       self.onSelect = { item in onSelect(item.data) }
+    }
+    if let onDeselect {
+      self.onDeselect = { item in onDeselect(item.data) }
     }
     if let onDelete {
       self.onDelete = { item in onDelete(item.data) }

--- a/Tests/ListKitTests/HeckelDiffTests.swift
+++ b/Tests/ListKitTests/HeckelDiffTests.swift
@@ -171,6 +171,28 @@ struct HeckelDiffTests {
     #expect(result.moves.isEmpty)
   }
 
+  /// LIS with all-duplicate old-indices should produce maximum moves.
+  @Test
+  func allDuplicateLISProducesMaximalMoves() {
+    // When every element appears in both arrays but none are unique,
+    // the expansion passes still match them. Verify we don't crash
+    // and the result is structurally valid.
+    let old = [1, 1, 2, 2, 3, 3]
+    let new = [3, 3, 1, 1, 2, 2]
+
+    let result = HeckelDiff.diff(old: old, new: new)
+
+    // Net change should be zero (same multiset)
+    #expect(result.deletes.count == result.inserts.count)
+
+    // Every old index is accounted for
+    let oldCovered = Set(result.deletes + result.matched.map(\.old))
+    #expect(oldCovered == Set(0 ..< old.count))
+
+    let newCovered = Set(result.inserts + result.matched.map(\.new))
+    #expect(newCovered == Set(0 ..< new.count))
+  }
+
   /// Verify that applying deletes + inserts + moves reconstructs the new array.
   @Test
   func movesReconstructNewArray() {

--- a/Tests/ListKitTests/SectionSnapshotTests.swift
+++ b/Tests/ListKitTests/SectionSnapshotTests.swift
@@ -203,6 +203,29 @@ struct SectionSnapshotTests {
   }
 
   @Test
+  func deleteParentLeavesNoOrphanedReferences() {
+    // Delete a parent and verify that children are also removed,
+    // and no dangling parent references remain.
+    var snapshot = DiffableDataSourceSectionSnapshot<String>()
+    snapshot.append(["A", "B"])
+    snapshot.append(["A1", "A2"], to: "A")
+    snapshot.append(["A1a"], to: "A1")
+    snapshot.expand(["A", "A1"])
+
+    // Delete the parent "A" — children should cascade
+    snapshot.delete(["A"])
+    #expect(!snapshot.contains("A"))
+    #expect(!snapshot.contains("A1"))
+    #expect(!snapshot.contains("A2"))
+    #expect(!snapshot.contains("A1a"))
+    #expect(snapshot.items == ["B"])
+
+    // "B" should still be a valid root
+    #expect(snapshot.parent(of: "B") == nil)
+    #expect(snapshot.rootItems == ["B"])
+  }
+
+  @Test
   func sendableConformance() {
     let snapshot = DiffableDataSourceSectionSnapshot<String>()
     let _: any Sendable = snapshot

--- a/Tests/ListsTests/GroupedListTests.swift
+++ b/Tests/ListsTests/GroupedListTests.swift
@@ -129,4 +129,32 @@ struct GroupedListTests {
     list.onDelete?(TextItem(text: "Z"))
     #expect(deletedItem?.text == "Z")
   }
+
+  @Test
+  func onMoveCallbackIsWired() {
+    let list = GroupedList<String, TextItem>()
+
+    var movedSource: IndexPath?
+    var movedDest: IndexPath?
+    list.onMove = { source, dest in
+      movedSource = source
+      movedDest = dest
+    }
+
+    #expect(list.collectionView.dragInteractionEnabled == true)
+
+    list.onMove?(IndexPath(item: 0, section: 0), IndexPath(item: 1, section: 0))
+    #expect(movedSource == IndexPath(item: 0, section: 0))
+    #expect(movedDest == IndexPath(item: 1, section: 0))
+  }
+
+  @Test
+  func clearingOnMoveDisablesDragInteraction() {
+    let list = GroupedList<String, TextItem>()
+    list.onMove = { _, _ in }
+    #expect(list.collectionView.dragInteractionEnabled == true)
+
+    list.onMove = nil
+    #expect(list.collectionView.dragInteractionEnabled == false)
+  }
 }

--- a/Tests/ListsTests/SimpleListTests.swift
+++ b/Tests/ListsTests/SimpleListTests.swift
@@ -127,4 +127,48 @@ struct SimpleListTests {
     list.onDeselect?(TextItem(text: "Y"))
     #expect(deselectedItem?.text == "Y")
   }
+
+  @Test
+  func onMoveCallbackIsWired() {
+    let list = SimpleList<TextItem>()
+
+    var movedSource: IndexPath?
+    var movedDest: IndexPath?
+    list.onMove = { source, dest in
+      movedSource = source
+      movedDest = dest
+    }
+
+    #expect(list.collectionView.dragInteractionEnabled == true)
+
+    // Invoke the callback directly to verify wiring
+    list.onMove?(IndexPath(item: 0, section: 0), IndexPath(item: 1, section: 0))
+    #expect(movedSource == IndexPath(item: 0, section: 0))
+    #expect(movedDest == IndexPath(item: 1, section: 0))
+  }
+
+  @Test
+  func clearingOnMoveDisablesDragInteraction() {
+    let list = SimpleList<TextItem>()
+    list.onMove = { _, _ in }
+    #expect(list.collectionView.dragInteractionEnabled == true)
+
+    list.onMove = nil
+    #expect(list.collectionView.dragInteractionEnabled == false)
+  }
+
+  @Test
+  func showsSeparatorsDefaultIsTrue() {
+    let list = SimpleList<TextItem>()
+    // The default initializer uses showsSeparators: true.
+    // We verify the layout was created (we can't inspect the layout config directly,
+    // but we can verify the list was created successfully with the parameter).
+    #expect(list.collectionView.collectionViewLayout is UICollectionViewCompositionalLayout)
+  }
+
+  @Test
+  func showsSeparatorsFalseCreatesValidLayout() {
+    let list = SimpleList<TextItem>(showsSeparators: false)
+    #expect(list.collectionView.collectionViewLayout is UICollectionViewCompositionalLayout)
+  }
 }


### PR DESCRIPTION
…d tests

- Add bounds check and assertionFailure in moveItemAt to prevent crash on out-of-range destination section
- Add assertion cap on fallbackRegistrations to catch unbounded growth
- Cache itemSet as local variable in snapshot(of:) to avoid repeated property access during loop
- Add consistent assertionFailure in didDeselectItemAt across all three list configurations (SimpleList, GroupedList, OutlineList)
- Add onDelete doc comments clarifying caller must update data source
- Add inline trailingProvider precedence comments
- Add OutlineList doc note explaining why onMove is intentionally absent
- Forward onDeselect through all three SwiftUI wrappers (SimpleListView, GroupedListView, OutlineListView) including inline content inits
- Document empty string behavior on ListAccessory.label
- Extract shared makeLayout helper in LayoutHelpers to reduce triplication
- Add moveItemAt snapshot mutation tests (within-section and cross-section)
- Add didMoveItemHandler callback test
- Add all-duplicates LIS edge case test
- Add delete-parent orphaned references test for SectionSnapshot
- Add onMove callback wiring tests for SimpleList and GroupedList
- Add showsSeparators layout creation tests