### PR TITLE
Add nested AGENTS.md structure with CLAUDE.md symlinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# ListKit — Agent Instructions
+
+> **This file is the source of truth.** `CLAUDE.md` is a symlink to this file.
+> Agents should create and update `AGENTS.md` files (never edit `CLAUDE.md` directly — it's a symlink).
+> When creating a new `AGENTS.md`, always create a corresponding `CLAUDE.md` symlink:
+> `ln -s AGENTS.md CLAUDE.md`
+
+## Project Overview
+
+ListKit is a high-performance, type-safe UICollectionView framework for iOS, organized as two Swift modules in a single package:
+
+- **ListKit** (`Sources/ListKit/`) — Low-level diffing engine. Drop-in replacement for `UICollectionViewDiffableDataSource` with an O(n) Heckel diff algorithm.
+- **Lists** (`Sources/Lists/`) — High-level declarative API built on ListKit. Provides ViewModel-driven data sources, result-builder DSL, pre-built configurations, and SwiftUI wrappers.
+
+Lists depends on ListKit. External consumers import either `ListKit` (low-level) or `Lists` (high-level; must also `import ListKit` separately if using its types directly).
+
+## Architecture
+
+```
+SwiftUI Wrappers (SimpleListView, GroupedListView, OutlineListView)
+        ↓
+Pre-Built Configurations (SimpleList, GroupedList, OutlineList)
+        ↓
+Data Sources (ListDataSource, MixedListDataSource)
+        ↓
+Builder DSL + Protocols (CellViewModel, SnapshotBuilder, AnyItem)
+        ↓
+ListKit Core (Snapshot, HeckelDiff, SectionedDiff, CollectionViewDiffableDataSource)
+```
+
+## Build & Test
+
+**Always use the Makefile** for building, testing, formatting, and other project tasks. The Makefile wraps complex `xcodebuild` invocations with the correct workspace, scheme, destination, and derived data paths. Do not invoke `xcodebuild` or `swift build` directly — use `make` targets instead.
+
+| Command | Description |
+|---|---|
+| `make setup` | First-time setup (install Tuist, generate project, install hooks) |
+| `make build` | Build both frameworks |
+| `make test` | Run all tests |
+| `make test-listkit` | Run ListKit tests only |
+| `make test-lists` | Run Lists tests only |
+| `make benchmark` | Run comparative benchmarks |
+| `make format` | Format code with SwiftFormat |
+| `make lint` | Lint code with SwiftFormat |
+| `make docs` | Generate DocC documentation |
+| `make open` | Open in Xcode |
+
+Tests require an iOS Simulator destination. The Makefile defaults to `iPhone 17 Pro`.
+
+## Code Style
+
+- **Swift 6** strict concurrency — all public types must be `Sendable`
+- **SwiftFormat** with Airbnb-based config (see `.swiftformat`)
+  - 2-space indentation
+  - Max line width: 130 (recommend ≤100)
+  - `--self remove` (no explicit `self`)
+  - Trailing commas on multi-element collections only
+  - `organizeDeclarations` is enabled — declaration order matters
+- Run `make format` before committing
+- Run `make lint` to check without modifying
+
+## Performance
+
+**Performance is the #1 priority for the ListKit module.** ListKit exists because Apple's implementation is too slow — every change to `Sources/ListKit/` must preserve or improve performance.
+
+Any change that could affect performance **must**:
+1. Run `make benchmark` before and after the change
+2. Compare results to confirm no regression
+3. Update the README with new numbers if baselines change
+
+Do not merge changes that regress benchmark numbers without explicit approval. See [`Sources/ListKit/AGENTS.md`](Sources/ListKit/AGENTS.md) for current baselines and details.
+
+## Key Conventions
+
+- **`CellViewModel` protocol** is the core abstraction in Lists. Requires `Hashable` + `Sendable`. Optionally conform to `Identifiable` to get free `Hashable`/`Equatable` from `id`.
+- **Value types everywhere** — snapshots, changesets, and section models are all structs.
+- **No runtime introspection** — everything is resolved at compile time via generics and protocols.
+- **`@MainActor` isolation** — data sources and configurations are `@MainActor`-bound.
+- **Parallel array storage** — snapshots use a flat `[Section]` array alongside a parallel `[[Item]]` (items-per-section) array, avoiding dictionary overhead.
+
+## File Organization
+
+Each directory with an `AGENTS.md` has module-specific instructions:
+
+- [`Sources/ListKit/AGENTS.md`](Sources/ListKit/AGENTS.md) — Diffing engine internals
+- [`Sources/Lists/AGENTS.md`](Sources/Lists/AGENTS.md) — High-level API, SwiftUI, DSL
+- [`Tests/AGENTS.md`](Tests/AGENTS.md) — Testing patterns and benchmarks
+- [`Example/AGENTS.md`](Example/AGENTS.md) — Demo app conventions
+
+## Updating These Instructions
+
+Agents are **encouraged** to create and update `AGENTS.md` files as they learn about the codebase. When doing so:
+
+1. Always edit `AGENTS.md` (never `CLAUDE.md` — it's a symlink)
+2. When creating a new `AGENTS.md` in a subdirectory, also create the symlink:
+   ```sh
+   ln -s AGENTS.md CLAUDE.md
+   ```
+3. Keep instructions factual, concise, and specific to the directory's scope
+4. Update instructions when code patterns change (e.g., new conventions, renamed types)
+5. Don't duplicate information from parent `AGENTS.md` — child files inherit parent context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Example/AGENTS.md
+++ b/Example/AGENTS.md
@@ -1,0 +1,38 @@
+# Example App — Agent Instructions
+
+> `CLAUDE.md` is a symlink to this file. Always edit `AGENTS.md`.
+
+## Purpose
+
+The Example app is a demo/showcase for ListKit and Lists features. It is built with Tuist (not SPM) and lives outside the main package targets.
+
+## Structure
+
+```
+Example/
+├── Project.swift                        — Tuist project manifest
+└── Sources/
+    ├── AppDelegate.swift                — App lifecycle
+    ├── SceneDelegate.swift              — Window setup with tab bar
+    ├── ListKitExampleViewController.swift    — Raw ListKit API usage
+    ├── DSLExampleViewController.swift        — ListDataSource with DSL
+    ├── LiveExampleViewController.swift       — Real-time updates demo
+    ├── GroupedListExampleViewController.swift — Multi-section grouped list
+    ├── OutlineExampleViewController.swift    — Hierarchical expand/collapse
+    ├── MixedExampleViewController.swift      — Mixed cell types
+    ├── SwiftUIExampleViewController.swift    — SwiftUI wrappers hosted in UIKit
+    ├── SwiftUIWrappersExampleView.swift      — Pure SwiftUI list views
+    └── ChatExampleView.swift                — Chat UI example
+```
+
+## Conventions
+
+- Each example is a standalone view controller or SwiftUI view
+- Examples should be self-contained — define their own ViewModels inline
+- The `SceneDelegate` builds a tab bar with one tab per example
+- To add a new example: create the VC/View, add a tab in `SceneDelegate`
+- Open with `make open` (requires `make setup` first)
+
+## Build
+
+The Example app is part of the Tuist workspace, not the SPM package. It's built via Xcode, not `swift build`. Use `make open` to generate and open the workspace.

--- a/Example/CLAUDE.md
+++ b/Example/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/ListKit/AGENTS.md
+++ b/Sources/ListKit/AGENTS.md
@@ -1,0 +1,66 @@
+# ListKit Module — Agent Instructions
+
+> `CLAUDE.md` is a symlink to this file. Always edit `AGENTS.md`.
+
+## Module Purpose
+
+ListKit is the low-level diffing and data source engine. It provides:
+
+- A fast O(n) Heckel diff algorithm
+- `DiffableDataSourceSnapshot` — a value-type replacement for Apple's `NSDiffableDataSourceSnapshot`
+- `DiffableDataSourceSectionSnapshot` — hierarchical parent-child snapshot
+- `CollectionViewDiffableDataSource` — API-compatible replacement for `UICollectionViewDiffableDataSource`
+
+This module has **zero dependencies** beyond UIKit/Foundation.
+
+## Directory Structure
+
+```
+ListKit/
+├── Algorithm/
+│   ├── HeckelDiff.swift          — O(n) diff producing inserts/deletes/moves
+│   ├── SectionedDiff.swift       — Per-section diffing with cross-section move reconciliation
+│   └── StagedChangeset.swift     — Batches changes into safe UICollectionView update groups
+├── DataSource/
+│   └── CollectionViewDiffableDataSource.swift — Drop-in replacement for Apple's diffable data source
+├── Snapshot/
+│   ├── DiffableDataSourceSnapshot.swift        — Flat snapshot (sections + items)
+│   └── DiffableDataSourceSectionSnapshot.swift — Hierarchical snapshot (parent-child trees)
+└── ListKit.docc/                 — DocC documentation catalog
+```
+
+## Key Design Decisions
+
+- **Parallel array storage**: Snapshots store `sectionIdentifiers: [SectionIdentifierType]` and `sectionItemArrays: [[ItemIdentifierType]]` as parallel arrays, with a `sectionIndex` dictionary for O(1) section-to-position lookups. This avoids Foundation overhead.
+- **Lazy reverse map**: The `sectionIndex` dictionary (section ID → position) is eagerly rebuilt on section mutations. The `_itemToSection` reverse map (item → containing section) is built lazily on first use by mutation methods, avoiding construction cost in the common build-then-diff path.
+- **Staged changesets**: `StagedChangeset` groups all computed diffs (section/item deletes, inserts, moves, reloads, reconfigures) into a single value type. `CollectionViewDiffableDataSource.performApply()` applies these in the correct order within `performBatchUpdates` to satisfy UICollectionView's constraints.
+- **Generic constraints**: `SectionIdentifierType: Hashable & Sendable`, `ItemIdentifierType: Hashable & Sendable`.
+
+## Performance
+
+**Performance is the #1 priority for this module.** ListKit exists because Apple's implementation is too slow. Every change must preserve or improve performance.
+
+Current baselines:
+- Snapshot construction is ~752x faster than Apple's `NSDiffableDataSourceSnapshot`
+- Diff computation is ~2.8x faster than IGListKit at 10k items
+- The Heckel algorithm is O(n) average case (vs unknown complexity for Apple's diff)
+
+Benchmarks live in `Tests/Benchmarks/`.
+
+### Performance workflow
+
+Any change that could affect performance **must**:
+1. Run `make benchmark` before and after the change
+2. Compare results to confirm no regression
+3. Update the README with new numbers if baselines change
+
+Do not merge changes that regress benchmark numbers without explicit approval.
+
+## When Modifying This Module
+
+- Changes to the diff algorithm must not break `StagedChangeset` output ordering
+- Snapshot mutations must invalidate lazy index caches
+- All public types must conform to `Sendable`
+- `CollectionViewDiffableDataSource` must remain API-compatible with Apple's `UICollectionViewDiffableDataSource`
+- Run `make test-listkit` to verify correctness
+- Run `make benchmark` to verify performance (see Performance section above)

--- a/Sources/ListKit/CLAUDE.md
+++ b/Sources/ListKit/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/Lists/AGENTS.md
+++ b/Sources/Lists/AGENTS.md
@@ -1,0 +1,98 @@
+# Lists Module — Agent Instructions
+
+> `CLAUDE.md` is a symlink to this file. Always edit `AGENTS.md`.
+
+## Module Purpose
+
+Lists is the high-level, developer-facing API built on top of ListKit. It provides:
+
+- **`CellViewModel` protocol** — the core abstraction tying cell content to diffable identity
+- **Data sources** — `ListDataSource` (single type) and `MixedListDataSource` (heterogeneous)
+- **Result builder DSL** — `@SnapshotBuilder`, `@ItemsBuilder`, `@MixedSnapshotBuilder`
+- **Pre-built configurations** — `SimpleList`, `GroupedList`, `OutlineList`
+- **SwiftUI wrappers** — `SimpleListView`, `GroupedListView`, `OutlineListView`
+- **Accessories** — `ListAccessory` enum mapping to `UICellAccessory`
+
+## Directory Structure
+
+```
+Lists/
+├── Protocols/
+│   ├── CellViewModel.swift          — Core protocol: Hashable + Sendable + cell configuration
+│   └── SectionModel.swift           — Section metadata (header/footer text)
+├── DataSource/
+│   ├── ListDataSource.swift         — Single-cell-type data source with automatic registration
+│   └── MixedListDataSource.swift    — Heterogeneous cell types via AnyItem type erasure
+├── Builder/
+│   ├── SnapshotBuilder.swift        — @resultBuilder for single-type snapshots
+│   ├── ItemsBuilder.swift           — @resultBuilder for items within sections
+│   ├── MixedSnapshotBuilder.swift   — @resultBuilder for mixed-type snapshots (also defines MixedItemsBuilder and MixedSection)
+│   ├── DiffableDataSourceSnapshot+DSL.swift      — DSL extensions on Snapshot
+│   └── DiffableDataSourceSnapshot+MixedDSL.swift — Mixed DSL extensions
+├── Mixed/
+│   └── AnyItem.swift                — Type-erased CellViewModel wrapper (measured overhead)
+├── Configurations/
+│   ├── SimpleList.swift             — Single-section flat list
+│   ├── GroupedList.swift            — Multi-section with headers/footers
+│   ├── OutlineList.swift            — Hierarchical expand/collapse
+│   └── ListConfigurationBridge.swift — Shared configuration logic
+├── SwiftUI/
+│   ├── SimpleListView.swift         — SwiftUI wrapper for SimpleList
+│   ├── GroupedListView.swift        — SwiftUI wrapper for GroupedList
+│   ├── OutlineListView.swift        — SwiftUI wrapper for OutlineList
+│   ├── SwiftUICellViewModel.swift   — Protocol adding SwiftUI body + accessories
+│   ├── InlineCellViewModel.swift    — Type-erased inline SwiftUI content
+│   └── ListAccessory.swift          — Pure-Swift enum for UICellAccessory
+├── Extensions/
+│   ├── CellViewModel+Identifiable.swift   — Default Hashable/Equatable from id
+│   ├── LayoutHelpers.swift                — UICollectionLayoutListConfiguration shortcuts
+│   └── RefreshControlConfiguration.swift  — Pull-to-refresh support
+└── Lists.docc/                      — DocC documentation catalog
+```
+
+## Key Patterns
+
+### CellViewModel Protocol
+
+The single most important type in this module. A `CellViewModel` must:
+1. Conform to `Hashable` and `Sendable`
+2. Declare an associated `Cell` type (a `UICollectionViewCell` subclass)
+3. Implement `func configure(_ cell: Cell)` to bind data to the cell
+
+The default `Hashable`/`Equatable` implementations derive from `id`, provided by the `CellViewModel+Identifiable.swift` extension. Override only when content-based equality is needed.
+
+### Result Builder DSL
+
+The builders allow declarative snapshot construction:
+```swift
+dataSource.apply {
+  SnapshotSection("favorites") {
+    for item in favorites { item }
+  }
+  if showRecents {
+    SnapshotSection("recents") {
+      for item in recents { item }
+    }
+  }
+}
+```
+
+`@SnapshotBuilder` and `@MixedSnapshotBuilder` are top-level; `@ItemsBuilder` and `@MixedItemsBuilder` are used inside sections.
+
+### SwiftUI Integration
+
+SwiftUI wrappers use `UIViewRepresentable`. The `SwiftUICellViewModel` protocol extends `CellViewModel` with a SwiftUI `body` and optional `accessories`. `InlineCellViewModel` is the type-erased version for inline closures.
+
+### Mixed vs Single-Type
+
+- `ListDataSource<Item>` — fastest path, no type erasure
+- `MixedListDataSource` — wraps items in `AnyItem`, has measured overhead (~15-30%)
+- Prefer single-type unless the list truly has heterogeneous cell types
+
+## When Modifying This Module
+
+- New `CellViewModel` features must work with both `ListDataSource` and `MixedListDataSource`
+- Result builders must support `if`/`else`, `for`, and `Optional` in all positions
+- SwiftUI wrappers must call `updateUIView` correctly (avoid unnecessary reloads)
+- All configurations are `@MainActor` — don't break actor isolation
+- Run `make test-lists` to verify changes

--- a/Sources/Lists/CLAUDE.md
+++ b/Sources/Lists/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,0 +1,51 @@
+# Tests — Agent Instructions
+
+> `CLAUDE.md` is a symlink to this file. Always edit `AGENTS.md`.
+
+## Test Structure
+
+```
+Tests/
+├── ListKitTests/       — Unit tests for the ListKit diffing engine
+├── ListsTests/         — Unit + integration tests for the Lists high-level API
+│   └── Helpers/
+│       └── TestViewModels.swift  — Shared test fixtures
+└── Benchmarks/         — Comparative performance benchmarks
+```
+
+## Running Tests
+
+| Command | Scope |
+|---|---|
+| `make test` | All test targets |
+| `make test-listkit` | ListKitTests only |
+| `make test-lists` | ListsTests only |
+| `make benchmark` | Benchmarks (Release config, ENABLE_TESTABILITY=YES) |
+
+Tests run on iOS Simulator (`iPhone 17 Pro` by default).
+
+## Test Conventions
+
+- **Swift Testing** is the test framework (`import Testing`, `@Test`, `#expect`)
+- Test containers are plain `struct`s (not `XCTestCase` subclasses)
+- Test files mirror source file names: `HeckelDiff.swift` → `HeckelDiffTests.swift`
+- Use descriptive camelCase method names: `func emptySnapshot()`, `func appendSections()`
+- Shared fixtures live in `ListsTests/Helpers/TestViewModels.swift`
+- Tests that require a `UICollectionView` create one inline with a layout — no storyboards
+
+## Benchmarks
+
+Benchmarks compare ListKit against:
+- Apple's `NSDiffableDataSourceSnapshot`
+- IGListKit's `IGListDiff`
+- ReactiveCollectionsKit
+
+Benchmarks run in **Release** configuration for accurate measurements. They use a custom `benchmark { }` helper (median-of-N with warmup) and `#expect` assertions to verify ListKit is faster.
+
+## When Adding Tests
+
+- Place ListKit (algorithm/snapshot/data source) tests in `ListKitTests/`
+- Place Lists (CellViewModel/DSL/configuration/SwiftUI) tests in `ListsTests/`
+- Reuse existing test helpers from `TestViewModels.swift` where possible
+- New test ViewModels should be added to `TestViewModels.swift` if reusable
+- Run the full suite (`make test`) before submitting changes

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` agent instruction files at each module boundary (root, Sources/ListKit, Sources/Lists, Tests, Example)
- Each `AGENTS.md` has a corresponding `CLAUDE.md` symlink so Claude Code discovers them automatically
- Files document architecture, conventions, build commands, testing patterns, and module-specific constraints
- Agents are encouraged to create and update `AGENTS.md` files as they learn about the codebase

## Structure

| Location | Scope |
|---|---|
| `AGENTS.md` | Project overview, architecture diagram, build/test commands, code style, key conventions |
| `Sources/ListKit/AGENTS.md` | Diffing engine internals, design decisions, performance notes, modification constraints |
| `Sources/Lists/AGENTS.md` | CellViewModel protocol, result builder DSL, SwiftUI integration, mixed vs single-type guidance |
| `Tests/AGENTS.md` | Swift Testing conventions, test naming, benchmark patterns, where to place new tests |
| `Example/AGENTS.md` | Demo app structure, how to add new examples |

## Test plan

- [x] Verify all `CLAUDE.md` files are symlinks to `AGENTS.md` (confirmed via `readlink`)
- [x] Verify all symlinks resolve correctly (confirmed via `head -1`)
- [x] Cross-referenced claims against actual source code (fixed 4 inaccuracies found during review)
- [x] Confirmed files are not excluded by `.gitignore`
- [x] Confirmed symlinks stored as git mode `120000`