### PR TITLE
Add UIKit chat examples for Lists and ListKit frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **UIKit chat examples**: Two new UIKit counterparts to the existing SwiftUI chat example — `ListsChatExampleViewController` (`SimpleList` + `CellViewModel` + `UIHostingConfiguration`) and `ListKitChatExampleViewController` (raw `CollectionViewDiffableDataSource` with pure UIKit cells and manual cell reconfiguration).
+- **Shared chat input bar**: Reusable `ChatInputBar` UIKit view with keyboard layout guide support.
+
 ### Changed
 
 - **AGENTS.md pre-commit documentation check**: Agents are now prompted to reflect on whether they've discovered new codebase knowledge before every commit, and to update or create `AGENTS.md` files accordingly.

--- a/Example/AGENTS.md
+++ b/Example/AGENTS.md
@@ -22,7 +22,11 @@ Example/
     ├── MixedExampleViewController.swift      — Mixed cell types
     ├── SwiftUIExampleViewController.swift    — SwiftUI wrappers hosted in UIKit
     ├── SwiftUIWrappersExampleView.swift      — Pure SwiftUI list views
-    └── ChatExampleView.swift                — Chat UI example
+    ├── ChatExampleView.swift                — Chat UI (SwiftUI + SimpleListView)
+    ├── ChatShared.swift                     — Shared chat types, bubble view, scroll protocol
+    ├── ChatInputBar.swift                   — Shared UIKit input bar
+    ├── ListsChatExampleViewController.swift — Chat UI (UIKit + SimpleList + CellViewModel)
+    └── ListKitChatExampleViewController.swift — Chat UI (UIKit + raw CollectionViewDiffableDataSource)
 ```
 
 ## Conventions

--- a/Example/Sources/ChatExampleView.swift
+++ b/Example/Sources/ChatExampleView.swift
@@ -33,7 +33,9 @@ struct ChatExampleView: View {
           },
           scrollViewDelegate: store
         ) { [store] ref in
-          ChatBubbleView(model: store.model(for: ref.id))
+          if let model = store.model(for: ref.id) {
+            ChatBubbleView(model: model)
+          }
         }
 
         if store.showScrollToBottom {
@@ -74,49 +76,6 @@ struct ChatExampleView: View {
 
   // MARK: Private
 
-  private static let cannedConversation: [(question: String, answer: String)] = [
-    (
-      "What is Swift's actor model?",
-      "Swift actors provide data-race safety by isolating their mutable state. Only one task can access an actor's properties at a time, and all cross-actor calls are asynchronous. This eliminates a whole class of concurrency bugs at compile time rather than runtime."
-    ),
-    (
-      "How does diffable data source work?",
-      "NSDiffableDataSource takes snapshots of your data and automatically computes the difference between the old and new states. It then applies only the necessary insertions, deletions, and moves with smooth animations — no more calling reloadData or manually managing index paths."
-    ),
-    (
-      "What makes SwiftUI declarative?",
-      "In SwiftUI you describe what your UI should look like for a given state, and the framework figures out how to transition between states. You don't imperatively add or remove views — instead you express the view hierarchy as a function of your data, and SwiftUI handles the rest."
-    ),
-    (
-      "Explain structured concurrency.",
-      "Structured concurrency ties the lifetime of child tasks to their parent scope. When you use async let or a task group, child tasks are automatically cancelled if the parent is cancelled, and the parent waits for all children to finish. This prevents leaked tasks and makes concurrency predictable."
-    ),
-    (
-      "What is copy-on-write?",
-      "Copy-on-write is an optimization where value types like Array and Dictionary share the same underlying storage until one copy is mutated. At that point, Swift creates a unique copy of the buffer. This gives you the safety of value semantics with the performance of reference types for the common case where copies are never modified."
-    ),
-    (
-      "How do property wrappers work?",
-      "A property wrapper is a type that encapsulates read and write access to a property. You define a struct or class with a wrappedValue property, then annotate stored properties with @YourWrapper. The compiler synthesizes a backing _property that holds the wrapper instance. This is how @State, @Binding, @Published, and many other SwiftUI and Combine features work under the hood."
-    ),
-    (
-      "What are existential types in Swift?",
-      "An existential type is the runtime box Swift creates when you use a protocol as a type (e.g., `any Drawable`). It stores the value, a pointer to its type metadata, and a witness table of protocol conformances. Existentials add indirection and heap allocation, which is why Swift introduced the `any` keyword to make the cost explicit and encourages generics (`some Drawable`) when possible."
-    ),
-    (
-      "Explain Swift's result builder DSL.",
-      "Result builders transform a sequence of statements into a single value using static buildBlock, buildOptional, buildEither, and other methods. SwiftUI's @ViewBuilder is the most famous example — it turns your if/else and sequential view declarations into a type-erased tree of views. You can create your own result builders for HTML, regex, configuration DSLs, and more."
-    ),
-    (
-      "What is the Sendable protocol?",
-      "Sendable marks types that are safe to pass across concurrency boundaries. Value types with Sendable fields conform automatically, actors are always Sendable, and classes need to be final with immutable stored properties. The compiler checks Sendable constraints at boundaries like Task creation and actor calls, catching data races before they happen."
-    ),
-    (
-      "How does Swift's type inference work?",
-      "Swift's type inference uses a constraint-based solver. When you write `let x = [1, 2, 3]`, the compiler generates constraints from the literal expressions and context, then solves them to determine that x is [Int]. It works bidirectionally — context flows both from initializers upward and from type annotations downward. This is why you can write `.blue` instead of `Color.blue` when the expected type is known."
-    ),
-  ]
-
   @State private var store = ChatStore()
   @State private var inputText = ""
   @State private var stopDemo = false
@@ -130,9 +89,7 @@ struct ChatExampleView: View {
     store.addMessage(role: .user, text: text)
     store.scrollToBottomAfterInsert()
 
-    let response = Self.cannedConversation
-      .first { text.localizedCaseInsensitiveContains(String($0.question.prefix(20))) }?.answer
-      ?? "That's an interesting question! In a real app this is where the LLM API response would stream in token by token, with each update triggering a smooth diff in the collection view."
+    let response = ChatConversation.response(for: text)
 
     store.streamingTask?.cancel()
     store.streamingTask = Task {
@@ -165,7 +122,7 @@ struct ChatExampleView: View {
   private func runDemo() async {
     do { try await Task.sleep(for: .seconds(1)) } catch { return }
 
-    for qa in Self.cannedConversation {
+    for qa in ChatConversation.canned {
       guard !stopDemo else { return }
 
       store.addMessage(role: .user, text: qa.question)
@@ -182,7 +139,7 @@ struct ChatExampleView: View {
 
 @Observable
 @MainActor
-final class ChatStore: NSObject, UIScrollViewDelegate {
+final class ChatStore: NSObject, UIScrollViewDelegate, ChatScrollManaging {
 
   // MARK: Internal
 
@@ -202,45 +159,7 @@ final class ChatStore: NSObject, UIScrollViewDelegate {
   }
 
   func model(for id: UUID) -> ChatMessageModel? {
-    let result = models[id]
-    assert(result != nil, "ChatStore.model(for:) — no model found for id \(id)")
-    return result
-  }
-
-  /// Performs a non-animated layout pass so cell heights match their current content.
-  /// The text itself already updates smoothly via `@Observable` — this just keeps the
-  /// cell frame in sync without any UIKit animation artifacts.
-  func invalidateLayout() {
-    guard let collectionView else { return }
-    UIView.performWithoutAnimation {
-      collectionView.collectionViewLayout.invalidateLayout()
-      collectionView.layoutIfNeeded()
-    }
-    if isNearBottom, !collectionView.isTracking, !collectionView.isDecelerating {
-      scrollToBottom(animated: false)
-    }
-  }
-
-  func scrollToBottom(animated: Bool) {
-    guard let collectionView else { return }
-    let sections = collectionView.numberOfSections
-    guard sections > 0 else { return }
-    let lastSection = sections - 1
-    let items = collectionView.numberOfItems(inSection: lastSection)
-    guard items > 0 else { return }
-    collectionView.scrollToItem(
-      at: IndexPath(item: items - 1, section: lastSection),
-      at: .bottom,
-      animated: animated
-    )
-  }
-
-  func scrollToBottomAfterInsert() {
-    guard isNearBottom, let collectionView, !collectionView.isTracking, !collectionView.isDecelerating else { return }
-    // Dispatch to next run loop so the snapshot apply has finished layout.
-    DispatchQueue.main.async { [weak self] in
-      self?.scrollToBottom(animated: true)
-    }
+    models[id]
   }
 
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -253,100 +172,4 @@ final class ChatStore: NSObject, UIScrollViewDelegate {
   // MARK: Private
 
   private var models = [UUID: ChatMessageModel]()
-
-  private var isNearBottom: Bool {
-    guard let collectionView else { return true }
-    return isNearBottom(in: collectionView)
-  }
-
-  private func isNearBottom(in scrollView: UIScrollView) -> Bool {
-    let offsetY = scrollView.contentOffset.y
-    let contentHeight = scrollView.contentSize.height
-    let frameHeight = scrollView.bounds.height
-    let insetBottom = scrollView.adjustedContentInset.bottom
-    // Consider "near bottom" if within 80pt of the bottom edge.
-    return offsetY >= contentHeight - frameHeight - insetBottom - 80
-  }
-}
-
-// MARK: - ChatMessageRef
-
-struct ChatMessageRef: Hashable, Sendable {
-  let id: UUID
-}
-
-// MARK: - ChatMessageModel
-
-@Observable
-@MainActor
-final class ChatMessageModel {
-
-  // MARK: Lifecycle
-
-  init(role: Role, text: String, isStreaming: Bool = false) {
-    id = UUID()
-    self.role = role
-    self.text = text
-    self.isStreaming = isStreaming
-  }
-
-  // MARK: Internal
-
-  enum Role: Sendable {
-    case user
-    case assistant
-  }
-
-  let id: UUID
-  let role: Role
-  var text: String
-  var isStreaming: Bool
-}
-
-// MARK: - ChatBubbleView
-
-private struct ChatBubbleView: View {
-
-  // MARK: Internal
-
-  let model: ChatMessageModel?
-
-  var body: some View {
-    if let model {
-      HStack {
-        if model.role == .user {
-          Spacer(minLength: 60)
-        }
-
-        Text(displayText(for: model))
-          .padding(.horizontal, 12)
-          .padding(.vertical, 8)
-          .background(model.role == .user ? Color.blue : Color(.systemGray5))
-          .foregroundStyle(model.role == .user ? Color.white : Color.primary)
-          .clipShape(RoundedRectangle(cornerRadius: 16))
-          .contextMenu {
-            Button {
-              UIPasteboard.general.string = model.text
-            } label: {
-              Label("Copy", systemImage: "doc.on.doc")
-            }
-          }
-
-        if model.role == .assistant {
-          Spacer(minLength: 60)
-        }
-      }
-      .padding(.vertical, 2)
-      .transaction { $0.animation = nil }
-    }
-  }
-
-  // MARK: Private
-
-  private func displayText(for model: ChatMessageModel) -> String {
-    if model.isStreaming {
-      return model.text.isEmpty ? "▍" : model.text + " ▍"
-    }
-    return model.text
-  }
 }

--- a/Example/Sources/ChatInputBar.swift
+++ b/Example/Sources/ChatInputBar.swift
@@ -1,0 +1,105 @@
+import UIKit
+
+// MARK: - ChatInputBar
+
+/// Shared UIKit input bar used by the UIKit chat examples.
+///
+/// Contains a text field and send button in a horizontal layout with a top divider.
+/// Hook `onSend` to receive submitted text. Toggle `isSendEnabled` to control the send button.
+final class ChatInputBar: UIView, UITextFieldDelegate {
+
+  // MARK: Lifecycle
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setup()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  var onSend: ((String) -> Void)?
+
+  var isSendEnabled = true {
+    didSet {
+      updateSendButton()
+    }
+  }
+
+  func textFieldShouldReturn(_: UITextField) -> Bool {
+    submit()
+    return false
+  }
+
+  // MARK: Private
+
+  private let divider = UIView()
+  private let textField = UITextField()
+  private let sendButton = UIButton(type: .system)
+
+  private func setup() {
+    // Divider
+    divider.backgroundColor = .separator
+    divider.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(divider)
+
+    // Text field
+    textField.placeholder = "Message…"
+    textField.borderStyle = .roundedRect
+    textField.returnKeyType = .send
+    textField.delegate = self
+    textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(textField)
+
+    // Send button
+    let config = UIImage.SymbolConfiguration(textStyle: .title2)
+    sendButton.setImage(UIImage(systemName: "arrow.up.circle.fill", withConfiguration: config), for: .normal)
+    sendButton.addTarget(self, action: #selector(sendTapped), for: .touchUpInside)
+    sendButton.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(sendButton)
+
+    NSLayoutConstraint.activate([
+      divider.topAnchor.constraint(equalTo: topAnchor),
+      divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+      divider.trailingAnchor.constraint(equalTo: trailingAnchor),
+      divider.heightAnchor.constraint(equalToConstant: 1.0 / 3.0),
+
+      textField.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 8),
+      textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+      textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+
+      sendButton.leadingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 8),
+      sendButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+      sendButton.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
+    ])
+
+    updateSendButton()
+  }
+
+  @objc
+  private func sendTapped() {
+    submit()
+  }
+
+  @objc
+  private func textFieldDidChange() {
+    updateSendButton()
+  }
+
+  private func submit() {
+    guard let text = textField.text?.trimmingCharacters(in: .whitespaces), !text.isEmpty, isSendEnabled else { return }
+    textField.text = ""
+    updateSendButton()
+    onSend?(text)
+  }
+
+  private func updateSendButton() {
+    let hasText = !(textField.text?.trimmingCharacters(in: .whitespaces).isEmpty ?? true)
+    sendButton.isEnabled = hasText && isSendEnabled
+  }
+}

--- a/Example/Sources/ChatShared.swift
+++ b/Example/Sources/ChatShared.swift
@@ -1,0 +1,199 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+// MARK: - ChatMessageRef
+
+struct ChatMessageRef: Hashable, Sendable {
+  let id: UUID
+}
+
+// MARK: - ChatMessageModel
+
+@Observable
+@MainActor
+final class ChatMessageModel {
+
+  // MARK: Lifecycle
+
+  init(role: Role, text: String, isStreaming: Bool = false) {
+    id = UUID()
+    self.role = role
+    self.text = text
+    self.isStreaming = isStreaming
+  }
+
+  // MARK: Internal
+
+  enum Role: Hashable, Sendable {
+    case user
+    case assistant
+  }
+
+  let id: UUID
+  let role: Role
+  var text: String
+  var isStreaming: Bool
+
+  /// Display text with a streaming cursor when active.
+  var displayText: String {
+    if isStreaming {
+      return text.isEmpty ? "▍" : text + " ▍"
+    }
+    return text
+  }
+}
+
+// MARK: - ChatBubbleView
+
+/// Reusable SwiftUI chat bubble used by the SwiftUI and Lists chat examples.
+struct ChatBubbleView: View {
+
+  let model: ChatMessageModel
+
+  var body: some View {
+    HStack {
+      if model.role == .user {
+        Spacer(minLength: 60)
+      }
+
+      Text(model.displayText)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(model.role == .user ? Color.blue : Color(.systemGray5))
+        .foregroundStyle(model.role == .user ? Color.white : Color.primary)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .contextMenu {
+          Button {
+            UIPasteboard.general.string = model.text
+          } label: {
+            Label("Copy", systemImage: "doc.on.doc")
+          }
+        }
+
+      if model.role == .assistant {
+        Spacer(minLength: 60)
+      }
+    }
+    .padding(.vertical, 2)
+    .transaction { $0.animation = nil }
+  }
+}
+
+// MARK: - ChatConversation
+
+enum ChatConversation {
+  static let canned: [(question: String, answer: String)] = [
+    (
+      "What is Swift's actor model?",
+      "Swift actors provide data-race safety by isolating their mutable state. Only one task can access an actor's properties at a time, and all cross-actor calls are asynchronous. This eliminates a whole class of concurrency bugs at compile time rather than runtime."
+    ),
+    (
+      "How does diffable data source work?",
+      "NSDiffableDataSource takes snapshots of your data and automatically computes the difference between the old and new states. It then applies only the necessary insertions, deletions, and moves with smooth animations — no more calling reloadData or manually managing index paths."
+    ),
+    (
+      "What makes SwiftUI declarative?",
+      "In SwiftUI you describe what your UI should look like for a given state, and the framework figures out how to transition between states. You don't imperatively add or remove views — instead you express the view hierarchy as a function of your data, and SwiftUI handles the rest."
+    ),
+    (
+      "Explain structured concurrency.",
+      "Structured concurrency ties the lifetime of child tasks to their parent scope. When you use async let or a task group, child tasks are automatically cancelled if the parent is cancelled, and the parent waits for all children to finish. This prevents leaked tasks and makes concurrency predictable."
+    ),
+    (
+      "What is copy-on-write?",
+      "Copy-on-write is an optimization where value types like Array and Dictionary share the same underlying storage until one copy is mutated. At that point, Swift creates a unique copy of the buffer. This gives you the safety of value semantics with the performance of reference types for the common case where copies are never modified."
+    ),
+    (
+      "How do property wrappers work?",
+      "A property wrapper is a type that encapsulates read and write access to a property. You define a struct or class with a wrappedValue property, then annotate stored properties with @YourWrapper. The compiler synthesizes a backing _property that holds the wrapper instance. This is how @State, @Binding, @Published, and many other SwiftUI and Combine features work under the hood."
+    ),
+    (
+      "What are existential types in Swift?",
+      "An existential type is the runtime box Swift creates when you use a protocol as a type (e.g., `any Drawable`). It stores the value, a pointer to its type metadata, and a witness table of protocol conformances. Existentials add indirection and heap allocation, which is why Swift introduced the `any` keyword to make the cost explicit and encourages generics (`some Drawable`) when possible."
+    ),
+    (
+      "Explain Swift's result builder DSL.",
+      "Result builders transform a sequence of statements into a single value using static buildBlock, buildOptional, buildEither, and other methods. SwiftUI's @ViewBuilder is the most famous example — it turns your if/else and sequential view declarations into a type-erased tree of views. You can create your own result builders for HTML, regex, configuration DSLs, and more."
+    ),
+    (
+      "What is the Sendable protocol?",
+      "Sendable marks types that are safe to pass across concurrency boundaries. Value types with Sendable fields conform automatically, actors are always Sendable, and classes need to be final with immutable stored properties. The compiler checks Sendable constraints at boundaries like Task creation and actor calls, catching data races before they happen."
+    ),
+    (
+      "How does Swift's type inference work?",
+      "Swift's type inference uses a constraint-based solver. When you write `let x = [1, 2, 3]`, the compiler generates constraints from the literal expressions and context, then solves them to determine that x is [Int]. It works bidirectionally — context flows both from initializers upward and from type annotations downward. This is why you can write `.blue` instead of `Color.blue` when the expected type is known."
+    ),
+  ]
+
+  /// Returns a canned response matching the input, or a generic fallback.
+  static func response(for input: String) -> String {
+    canned
+      .first { input.localizedCaseInsensitiveContains(String($0.question.prefix(20))) }?.answer
+      ?? "That's an interesting question! In a real app this is where the LLM API response would stream in token by token, with each update triggering a smooth diff in the collection view."
+  }
+}
+
+// MARK: - ChatScrollManaging
+
+/// Shared scroll-to-bottom behavior for chat stores.
+///
+/// Conforming types only need to provide a `collectionView` accessor —
+/// all scroll tracking, auto-scroll, and layout invalidation come for free.
+@MainActor
+protocol ChatScrollManaging: AnyObject {
+  var collectionView: UICollectionView? { get }
+}
+
+extension ChatScrollManaging {
+
+  var isNearBottom: Bool {
+    guard let collectionView else { return true }
+    return isNearBottom(in: collectionView)
+  }
+
+  func isNearBottom(in scrollView: UIScrollView) -> Bool {
+    let offsetY = scrollView.contentOffset.y
+    let contentHeight = scrollView.contentSize.height
+    let frameHeight = scrollView.bounds.height
+    let insetBottom = scrollView.adjustedContentInset.bottom
+    return offsetY >= contentHeight - frameHeight - insetBottom - 80
+  }
+
+  func scrollToBottom(animated: Bool) {
+    guard let collectionView else { return }
+    let sections = collectionView.numberOfSections
+    guard sections > 0 else { return }
+    let lastSection = sections - 1
+    let items = collectionView.numberOfItems(inSection: lastSection)
+    guard items > 0 else { return }
+    collectionView.scrollToItem(
+      at: IndexPath(item: items - 1, section: lastSection),
+      at: .bottom,
+      animated: animated
+    )
+  }
+
+  func scrollToBottomAfterInsert() {
+    guard isNearBottom, let collectionView, !collectionView.isTracking, !collectionView.isDecelerating else { return }
+    DispatchQueue.main.async { [weak self] in
+      self?.scrollToBottom(animated: true)
+    }
+  }
+
+  /// Invalidates layout without animation and auto-scrolls if near the bottom.
+  ///
+  /// Used during streaming to resize cells as text grows. The `performWithoutAnimation`
+  /// block prevents UIKit from animating the height change, while the auto-scroll keeps
+  /// the latest content visible.
+  func invalidateLayout() {
+    guard let collectionView else { return }
+    UIView.performWithoutAnimation {
+      collectionView.collectionViewLayout.invalidateLayout()
+      collectionView.layoutIfNeeded()
+    }
+    if isNearBottom, !collectionView.isTracking, !collectionView.isDecelerating {
+      scrollToBottom(animated: false)
+    }
+  }
+}

--- a/Example/Sources/ListKitChatExampleViewController.swift
+++ b/Example/Sources/ListKitChatExampleViewController.swift
@@ -1,0 +1,400 @@
+import ListKit
+import SwiftUI
+import UIKit
+
+// MARK: - ListKitChatExampleViewController
+
+/// Mock LLM chat interface demonstrating raw `CollectionViewDiffableDataSource` with pure UIKit cells.
+///
+/// Unlike the `Lists` counterparts that use `@Observable` + `UIHostingConfiguration` for automatic
+/// updates, this example manually reconfigures cells during streaming by directly setting a new
+/// `UIContentConfiguration` on the visible cell. This shows the lowest-level approach to building
+/// a performant chat interface with ListKit.
+final class ListKitChatExampleViewController: UIViewController, UICollectionViewDelegate {
+
+  // MARK: Lifecycle
+
+  deinit {
+    demoTask?.cancel()
+  }
+
+  // MARK: Internal
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    title = "Chat ListKit"
+    view.backgroundColor = .systemBackground
+
+    setupCollectionView()
+    setupInputBar()
+    setupScrollToBottomButton()
+
+    demoTask = Task {
+      await runDemo()
+    }
+  }
+
+  func collectionView(
+    _: UICollectionView,
+    contextMenuConfigurationForItemAt indexPath: IndexPath,
+    point _: CGPoint
+  ) -> UIContextMenuConfiguration? {
+    guard
+      let ref = dataSource.itemIdentifier(for: indexPath),
+      let model = store.model(for: ref.id)
+    else { return nil }
+
+    return UIContextMenuConfiguration(actionProvider: { _ in
+      UIMenu(children: [
+        UIAction(title: "Copy", image: UIImage(systemName: "doc.on.doc")) { _ in
+          UIPasteboard.general.string = model.text
+        }
+      ])
+    })
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    store.scrollViewDidScroll(scrollView)
+  }
+
+  // MARK: Private
+
+  private var collectionView: UICollectionView!
+  private var dataSource: CollectionViewDiffableDataSource<Int, ChatMessageRef>!
+  private let store = ListKitChatStore()
+  private let inputBar = ChatInputBar()
+  private nonisolated(unsafe) var demoTask: Task<Void, Never>?
+  private var stopDemo = false
+
+  private let scrollToBottomButton: UIButton = {
+    let config = UIImage.SymbolConfiguration(textStyle: .title1)
+    let image = UIImage(systemName: "chevron.down.circle.fill", withConfiguration: config)
+    let button = UIButton(type: .system)
+    button.setImage(image, for: .normal)
+    button.tintColor = .systemBlue
+    button.layer.shadowColor = UIColor.black.cgColor
+    button.layer.shadowOpacity = 0.25
+    button.layer.shadowRadius = 4
+    button.layer.shadowOffset = CGSize(width: 0, height: 2)
+    button.alpha = 0
+    button.translatesAutoresizingMaskIntoConstraints = false
+    return button
+  }()
+
+  private func setupCollectionView() {
+    var listConfig = UICollectionLayoutListConfiguration(appearance: .plain)
+    listConfig.showsSeparators = false
+    listConfig.headerTopPadding = 0
+    let layout = UICollectionViewCompositionalLayout.list(using: listConfig)
+
+    collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    collectionView.selfSizingInvalidation = .disabled
+    collectionView.allowsSelection = false
+    collectionView.delegate = self
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(collectionView)
+
+    let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, ChatMessageRef> {
+      [weak self] cell, _, ref in
+      guard let model = self?.store.model(for: ref.id) else {
+        assertionFailure("ChatStore missing model for ref \(ref.id)")
+        return
+      }
+      cell.contentConfiguration = ChatBubbleContentConfiguration(
+        role: model.role,
+        text: model.displayText,
+        isStreaming: model.isStreaming
+      )
+      cell.backgroundConfiguration = .clear()
+    }
+
+    dataSource = CollectionViewDiffableDataSource(collectionView: collectionView) { cv, indexPath, ref in
+      cv.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: ref)
+    }
+
+    store.collectionView = collectionView
+  }
+
+  private func setupInputBar() {
+    inputBar.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(inputBar)
+
+    inputBar.onSend = { [weak self] text in
+      self?.sendMessage(text)
+    }
+
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+      collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      collectionView.bottomAnchor.constraint(equalTo: inputBar.topAnchor),
+
+      inputBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      inputBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      inputBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+    ])
+  }
+
+  private func setupScrollToBottomButton() {
+    view.addSubview(scrollToBottomButton)
+    scrollToBottomButton.addTarget(self, action: #selector(scrollToBottomTapped), for: .touchUpInside)
+
+    NSLayoutConstraint.activate([
+      scrollToBottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+      scrollToBottomButton.bottomAnchor.constraint(equalTo: inputBar.topAnchor, constant: -12),
+    ])
+
+    store.onScrollToBottomChanged = { [weak self] show in
+      UIView.animate(withDuration: 0.2) {
+        self?.scrollToBottomButton.alpha = show ? 1 : 0
+        self?.scrollToBottomButton.transform = show ? .identity : CGAffineTransform(scaleX: 0.5, y: 0.5)
+      }
+    }
+  }
+
+  @objc
+  private func scrollToBottomTapped() {
+    store.scrollToBottom(animated: true)
+  }
+
+  private func sendMessage(_ text: String) {
+    guard !store.isStreaming else { return }
+    stopDemo = true
+
+    store.addMessage(role: .user, text: text)
+    applySnapshot()
+    store.scrollToBottomAfterInsert()
+
+    let response = ChatConversation.response(for: text)
+
+    store.streamingTask?.cancel()
+    store.streamingTask = Task {
+      await streamResponse(response)
+    }
+  }
+
+  private func streamResponse(_ response: String) async {
+    store.isStreaming = true
+    inputBar.isSendEnabled = false
+    do { try await Task.sleep(for: .milliseconds(400)) } catch {
+      store.isStreaming = false
+      inputBar.isSendEnabled = true
+      return
+    }
+
+    let model = store.addMessage(role: .assistant, text: "", isStreaming: true)
+    applySnapshot()
+    store.scrollToBottomAfterInsert()
+
+    let words = response.split(separator: " ").map(String.init)
+    for i in words.indices {
+      do { try await Task.sleep(for: .milliseconds(50)) } catch { break }
+      model.text = words[0...i].joined(separator: " ")
+
+      // Direct cell reconfiguration — no @Observable, no snapshot apply.
+      reconfigureStreamingCell(model: model)
+
+      store.invalidateLayout()
+    }
+
+    model.isStreaming = false
+    reconfigureStreamingCell(model: model)
+    store.invalidateLayout()
+
+    store.isStreaming = false
+    inputBar.isSendEnabled = true
+  }
+
+  /// Reconfigures the last cell in-place during streaming without a snapshot apply.
+  private func reconfigureStreamingCell(model: ChatMessageModel) {
+    guard
+      let ref = store.messageRefs.last,
+      let indexPath = dataSource.indexPath(for: ref),
+      let cell = collectionView.cellForItem(at: indexPath) as? UICollectionViewListCell
+    else { return }
+    cell.contentConfiguration = ChatBubbleContentConfiguration(
+      role: model.role,
+      text: model.displayText,
+      isStreaming: model.isStreaming
+    )
+  }
+
+  private func applySnapshot() {
+    var snapshot = DiffableDataSourceSnapshot<Int, ChatMessageRef>()
+    snapshot.appendSections([0])
+    snapshot.appendItems(store.messageRefs, toSection: 0)
+    dataSource.apply(snapshot, animatingDifferences: false)
+  }
+
+  private func runDemo() async {
+    do { try await Task.sleep(for: .seconds(1)) } catch { return }
+
+    for qa in ChatConversation.canned {
+      guard !stopDemo else { return }
+
+      store.addMessage(role: .user, text: qa.question)
+      applySnapshot()
+      store.scrollToBottomAfterInsert()
+      await streamResponse(qa.answer)
+
+      guard !stopDemo else { return }
+      do { try await Task.sleep(for: .seconds(2)) } catch { return }
+    }
+  }
+}
+
+// MARK: - ChatBubbleContentConfiguration
+
+/// Pure UIKit content configuration for chat bubbles, used with `UICollectionViewListCell`.
+///
+/// Unlike the Lists example that leverages `@Observable` + `UIHostingConfiguration`,
+/// this is a simple value type — each streaming tick creates a new instance.
+private struct ChatBubbleContentConfiguration: UIContentConfiguration, Hashable {
+
+  let role: ChatMessageModel.Role
+  let text: String
+  let isStreaming: Bool
+
+  func makeContentView() -> UIView & UIContentView {
+    ChatBubbleContentView(configuration: self)
+  }
+
+  func updated(for _: UIConfigurationState) -> ChatBubbleContentConfiguration {
+    self
+  }
+}
+
+// MARK: - ChatBubbleContentView
+
+/// Pure UIKit chat bubble with auto-layout constraints.
+///
+/// Alignment switches based on role: user bubbles align trailing (blue), assistant bubbles
+/// align leading (gray). Max width is capped at 75% of the container.
+private final class ChatBubbleContentView: UIView, UIContentView {
+
+  // MARK: Lifecycle
+
+  init(configuration: ChatBubbleContentConfiguration) {
+    appliedConfiguration = configuration
+    super.init(frame: .zero)
+    setup()
+    apply(configuration)
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Internal
+
+  var configuration: UIContentConfiguration {
+    get { appliedConfiguration }
+    set {
+      guard
+        let newConfig = newValue as? ChatBubbleContentConfiguration,
+        newConfig != appliedConfiguration
+      else { return }
+      appliedConfiguration = newConfig
+      apply(newConfig)
+    }
+  }
+
+  // MARK: Private
+
+  private var appliedConfiguration: ChatBubbleContentConfiguration
+
+  private let bubbleContainer = UIView()
+  private let label = UILabel()
+
+  private var leadingConstraint: NSLayoutConstraint!
+  private var trailingConstraint: NSLayoutConstraint!
+
+  private func setup() {
+    // Bubble container
+    bubbleContainer.layer.cornerRadius = 16
+    bubbleContainer.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(bubbleContainer)
+
+    // Label
+    label.numberOfLines = 0
+    label.font = .preferredFont(forTextStyle: .body)
+    label.adjustsFontForContentSizeCategory = true
+    label.translatesAutoresizingMaskIntoConstraints = false
+    bubbleContainer.addSubview(label)
+
+    // Constraints
+    leadingConstraint = bubbleContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)
+    trailingConstraint = bubbleContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
+
+    NSLayoutConstraint.activate([
+      bubbleContainer.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+      bubbleContainer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+      bubbleContainer.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 0.75),
+
+      label.topAnchor.constraint(equalTo: bubbleContainer.topAnchor, constant: 8),
+      label.bottomAnchor.constraint(equalTo: bubbleContainer.bottomAnchor, constant: -8),
+      label.leadingAnchor.constraint(equalTo: bubbleContainer.leadingAnchor, constant: 12),
+      label.trailingAnchor.constraint(equalTo: bubbleContainer.trailingAnchor, constant: -12),
+    ])
+  }
+
+  private func apply(_ config: ChatBubbleContentConfiguration) {
+    label.text = config.text
+
+    switch config.role {
+    case .user:
+      bubbleContainer.backgroundColor = .systemBlue
+      label.textColor = .white
+      leadingConstraint.isActive = false
+      trailingConstraint.isActive = true
+
+    case .assistant:
+      bubbleContainer.backgroundColor = .systemGray5
+      label.textColor = .label
+      trailingConstraint.isActive = false
+      leadingConstraint.isActive = true
+    }
+  }
+}
+
+// MARK: - ListKitChatStore
+
+@MainActor
+final class ListKitChatStore: NSObject, ChatScrollManaging {
+
+  // MARK: Internal
+
+  private(set) var messageRefs = [ChatMessageRef]()
+  var isStreaming = false
+  var streamingTask: Task<Void, Never>?
+
+  var onScrollToBottomChanged: ((Bool) -> Void)?
+
+  weak var collectionView: UICollectionView?
+
+  @discardableResult
+  func addMessage(role: ChatMessageModel.Role, text: String, isStreaming: Bool = false) -> ChatMessageModel {
+    let model = ChatMessageModel(role: role, text: text, isStreaming: isStreaming)
+    models[model.id] = model
+    messageRefs.append(ChatMessageRef(id: model.id))
+    return model
+  }
+
+  func model(for id: UUID) -> ChatMessageModel? {
+    models[id]
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    let nearBottom = isNearBottom(in: scrollView)
+    if showScrollToBottom == nearBottom {
+      showScrollToBottom = !nearBottom
+      onScrollToBottomChanged?(showScrollToBottom)
+    }
+  }
+
+  // MARK: Private
+
+  private var models = [UUID: ChatMessageModel]()
+  private var showScrollToBottom = false
+}

--- a/Example/Sources/ListsChatExampleViewController.swift
+++ b/Example/Sources/ListsChatExampleViewController.swift
@@ -1,0 +1,260 @@
+import Lists
+import SwiftUI
+import UIKit
+
+// MARK: - ListsChatExampleViewController
+
+/// Mock LLM chat interface demonstrating `SimpleList` + `CellViewModel` + `UIHostingConfiguration`.
+///
+/// This is the UIKit counterpart to `ChatExampleView` (SwiftUI). It uses the same `@Observable`
+/// `ChatMessageModel` to drive live updates — `UIHostingConfiguration` automatically re-renders
+/// when the observed model changes, so no manual cell reconfiguration is needed during streaming.
+final class ListsChatExampleViewController: UIViewController {
+
+  // MARK: Lifecycle
+
+  deinit {
+    demoTask?.cancel()
+  }
+
+  // MARK: Internal
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    title = "Chat Lists"
+    view.backgroundColor = .systemBackground
+
+    setupList()
+    setupInputBar()
+    setupScrollToBottomButton()
+
+    store.list = list
+
+    demoTask = Task {
+      await runDemo()
+    }
+  }
+
+  // MARK: Private
+
+  private var list: SimpleList<ChatBubbleItem>!
+  private let store = ListsChatStore()
+  private let inputBar = ChatInputBar()
+  private nonisolated(unsafe) var demoTask: Task<Void, Never>?
+  private var stopDemo = false
+
+  private let scrollToBottomButton: UIButton = {
+    let config = UIImage.SymbolConfiguration(textStyle: .title1)
+    let image = UIImage(systemName: "chevron.down.circle.fill", withConfiguration: config)
+    let button = UIButton(type: .system)
+    button.setImage(image, for: .normal)
+    button.tintColor = .systemBlue
+    button.layer.shadowColor = UIColor.black.cgColor
+    button.layer.shadowOpacity = 0.25
+    button.layer.shadowRadius = 4
+    button.layer.shadowOffset = CGSize(width: 0, height: 2)
+    button.alpha = 0
+    button.translatesAutoresizingMaskIntoConstraints = false
+    return button
+  }()
+
+  private func setupList() {
+    list = SimpleList<ChatBubbleItem>(
+      appearance: .plain,
+      showsSeparators: false,
+      headerTopPadding: 0,
+      selfSizingInvalidation: .disabled
+    )
+    list.scrollViewDelegate = store
+
+    list.contextMenuProvider = { item in
+      UIContextMenuConfiguration(actionProvider: { _ in
+        UIMenu(children: [
+          UIAction(title: "Copy", image: UIImage(systemName: "doc.on.doc")) { _ in
+            UIPasteboard.general.string = item.model.text
+          }
+        ])
+      })
+    }
+
+    let cv = list.collectionView
+    cv.allowsSelection = false
+    cv.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(cv)
+  }
+
+  private func setupInputBar() {
+    inputBar.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(inputBar)
+
+    inputBar.onSend = { [weak self] text in
+      self?.sendMessage(text)
+    }
+
+    let cv = list.collectionView
+    NSLayoutConstraint.activate([
+      cv.topAnchor.constraint(equalTo: view.topAnchor),
+      cv.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      cv.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      cv.bottomAnchor.constraint(equalTo: inputBar.topAnchor),
+
+      inputBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      inputBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      inputBar.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+    ])
+  }
+
+  private func setupScrollToBottomButton() {
+    view.addSubview(scrollToBottomButton)
+    scrollToBottomButton.addTarget(self, action: #selector(scrollToBottomTapped), for: .touchUpInside)
+
+    NSLayoutConstraint.activate([
+      scrollToBottomButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+      scrollToBottomButton.bottomAnchor.constraint(equalTo: inputBar.topAnchor, constant: -12),
+    ])
+
+    store.onScrollToBottomChanged = { [weak self] show in
+      UIView.animate(withDuration: 0.2) {
+        self?.scrollToBottomButton.alpha = show ? 1 : 0
+        self?.scrollToBottomButton.transform = show ? .identity : CGAffineTransform(scaleX: 0.5, y: 0.5)
+      }
+    }
+  }
+
+  @objc
+  private func scrollToBottomTapped() {
+    store.scrollToBottom(animated: true)
+  }
+
+  private func sendMessage(_ text: String) {
+    guard !store.isStreaming else { return }
+    stopDemo = true
+
+    store.addMessage(role: .user, text: text)
+    applySnapshot(scrollToBottom: true)
+
+    let response = ChatConversation.response(for: text)
+
+    store.streamingTask?.cancel()
+    store.streamingTask = Task {
+      await streamResponse(response)
+    }
+  }
+
+  private func streamResponse(_ response: String) async {
+    store.isStreaming = true
+    inputBar.isSendEnabled = false
+    do { try await Task.sleep(for: .milliseconds(400)) } catch {
+      store.isStreaming = false
+      inputBar.isSendEnabled = true
+      return
+    }
+
+    let model = store.addMessage(role: .assistant, text: "", isStreaming: true)
+    applySnapshot(scrollToBottom: true)
+
+    let words = response.split(separator: " ").map(String.init)
+    for i in words.indices {
+      do { try await Task.sleep(for: .milliseconds(50)) } catch { break }
+      model.text = words[0...i].joined(separator: " ")
+      store.invalidateLayout()
+    }
+
+    model.isStreaming = false
+    store.invalidateLayout()
+    store.isStreaming = false
+    inputBar.isSendEnabled = true
+  }
+
+  /// Applies the current items and optionally scrolls to the bottom after the snapshot lands.
+  private func applySnapshot(scrollToBottom: Bool = false) {
+    Task {
+      await list.setItems(store.items, animatingDifferences: false)
+      if scrollToBottom {
+        store.scrollToBottomAfterInsert()
+      }
+    }
+  }
+
+  private func runDemo() async {
+    do { try await Task.sleep(for: .seconds(1)) } catch { return }
+
+    for qa in ChatConversation.canned {
+      guard !stopDemo else { return }
+
+      store.addMessage(role: .user, text: qa.question)
+      applySnapshot(scrollToBottom: true)
+      await streamResponse(qa.answer)
+
+      guard !stopDemo else { return }
+      do { try await Task.sleep(for: .seconds(2)) } catch { return }
+    }
+  }
+}
+
+// MARK: - ChatBubbleItem
+
+/// `CellViewModel` that wraps a `ChatMessageModel` and renders via `UIHostingConfiguration`.
+///
+/// Equality is based on `id` alone — the `@Observable` model handles content updates automatically
+/// without requiring the diffable data source to detect value changes.
+struct ChatBubbleItem: CellViewModel, Identifiable {
+
+  let id: UUID
+  let model: ChatMessageModel
+
+  static func ==(lhs: ChatBubbleItem, rhs: ChatBubbleItem) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+
+  func configure(_ cell: UICollectionViewListCell) {
+    cell.contentConfiguration = UIHostingConfiguration {
+      ChatBubbleView(model: model)
+    }
+    .margins(.all, 0)
+    cell.backgroundConfiguration = .clear()
+  }
+}
+
+// MARK: - ListsChatStore
+
+@MainActor
+final class ListsChatStore: NSObject, UIScrollViewDelegate, ChatScrollManaging {
+
+  // MARK: Internal
+
+  private(set) var items = [ChatBubbleItem]()
+  var isStreaming = false
+  var streamingTask: Task<Void, Never>?
+
+  var onScrollToBottomChanged: ((Bool) -> Void)?
+
+  weak var list: SimpleList<ChatBubbleItem>?
+
+  var collectionView: UICollectionView? {
+    list?.collectionView
+  }
+
+  @discardableResult
+  func addMessage(role: ChatMessageModel.Role, text: String, isStreaming: Bool = false) -> ChatMessageModel {
+    let model = ChatMessageModel(role: role, text: text, isStreaming: isStreaming)
+    items.append(ChatBubbleItem(id: model.id, model: model))
+    return model
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    let nearBottom = isNearBottom(in: scrollView)
+    if showScrollToBottom == nearBottom {
+      showScrollToBottom = !nearBottom
+      onScrollToBottomChanged?(showScrollToBottom)
+    }
+  }
+
+  // MARK: Private
+
+  private var showScrollToBottom = false
+}

--- a/Example/Sources/SceneDelegate.swift
+++ b/Example/Sources/SceneDelegate.swift
@@ -33,6 +33,16 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         title: "Chat",
         icon: "bubble.left.and.bubble.right"
       ),
+      makeTab(
+        ListsChatExampleViewController(),
+        title: "Chat Lists",
+        icon: "bubble.left.and.text.bubble.right"
+      ),
+      makeTab(
+        ListKitChatExampleViewController(),
+        title: "Chat ListKit",
+        icon: "ellipsis.message"
+      ),
     ]
 
     window = UIWindow(windowScene: windowScene)


### PR DESCRIPTION
## Summary

- Extract shared chat types (`ChatMessageModel`, `ChatMessageRef`, `ChatConversation`) into `ChatShared.swift` to avoid code duplication
- Add `ListsChatExampleViewController` — UIKit + `SimpleList<CellViewModel>` + `UIHostingConfiguration` with `@Observable`-driven streaming updates
- Add `ListKitChatExampleViewController` — UIKit + raw `CollectionViewDiffableDataSource` with pure UIKit cells (`UIContentConfiguration`) and manual cell reconfiguration
- Add shared `ChatInputBar` UIKit view with keyboard layout guide support
- Register both new examples as tabs in `SceneDelegate`

All three chat examples (SwiftUI, UIKit+Lists, UIKit+ListKit) demonstrate identical functionality at different abstraction levels: streaming text, scroll-to-bottom, context menu copy, auto-demo, and user input.

| Aspect | SwiftUI | UIKit + Lists | UIKit + ListKit |
|--------|---------|---------------|-----------------|
| Data source | `SimpleListView` | `SimpleList<CellViewModel>` | `CollectionViewDiffableDataSource` |
| Cell rendering | `@ViewBuilder` | `UIHostingConfiguration` | `UIContentConfiguration` (pure UIKit) |
| Streaming updates | `@Observable` auto | `@Observable` auto | Direct cell reconfiguration |
| Input | SwiftUI `TextField` | `ChatInputBar` (UIKit) | `ChatInputBar` (UIKit) |

## Test plan

- [ ] Build the Example app target (verified: BUILD SUCCEEDED with Swift 6 strict concurrency)
- [ ] Launch in simulator and verify all three Chat tabs auto-demo correctly
- [ ] Send a custom message in each tab, verify streaming + scroll behavior
- [ ] Scroll up during streaming, verify scroll-to-bottom button appears
- [ ] Long-press a message, verify Copy context menu works
- [ ] Rotate device, verify layout adapts
- [ ] Existing tests pass (verified: ListKit 161/161, Lists 135/135)