### PR TITLE
Backfill CHANGELOG.md for 0.2.0, 0.3.0, and 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-02-15
+
+### Added
+
+- **`ListAccessory.toggle`**: Inline `UISwitch` accessory for settings screens with `isOn` binding and `onChange` callback.
+- **`ListAccessory.badge`**: Pill-shaped count/status badge via `BadgeLabel` subclass with tint color propagation.
+- **`ListAccessory.image`**: SF Symbol trailing icon accessory with debug assertions for invalid symbol names.
+- **`ListAccessory.progress`**: Small inline progress bar (60pt width) with out-of-range value assertions.
+- **`ListAccessory.activityIndicator`**: Spinning indicator accessory for loading states.
+
+### Changed
+
+- **`ListAccessory.uiAccessory`** is now `@MainActor`-isolated for UIKit thread safety.
+
+## [0.3.0] - 2026-02-15
+
+### Added
+
+- **Scroll view delegate forwarding**: `SimpleList`, `GroupedList`, and `OutlineList` now forward `UIScrollViewDelegate` callbacks so consumers can receive scroll events without replacing the collection view's delegate.
+- **`collectionViewHandler` and `scrollViewDelegate` parameters** added to `GroupedListView` and `OutlineListView` for API parity with `SimpleListView`.
+- **`selfSizingInvalidation` parameter** on `SimpleList` and `SimpleListView` for controlling cell resize behavior during streaming content.
+- **Chat example**: New `ChatExampleView` demonstrating streaming chat with manual layout invalidation, scroll-to-bottom tracking, and bubble-scoped context menus.
+
+## [0.2.0] - 2026-02-15
+
+### Added
+
+- **`onDelete` callback**: Automatic trailing swipe action generation for item deletion across all list configurations.
+- **`onMove` with drag-and-drop reorder**: Full drag-and-drop reorder infrastructure on `SimpleList` and `GroupedList` with `canMoveItemHandler` and `didMoveItemHandler` callbacks.
+- **`onDeselect` callback**: Multi-selection deselection support forwarded through all SwiftUI wrappers.
+- **`showsSeparators` parameter**: Native UIKit separator visibility toggle on all list configurations and `LayoutHelpers` factory methods.
+- **`ListAccessory.label`**: Text label accessory case.
+- **`ListAccessory.detail`**: Detail accessory with optional action handler.
+- **`ListAccessory.multiselect`**: Multi-selection checkmark accessory.
+- **`ListAccessory.popUpMenu`**: Pop-up menu accessory.
+- **UICollectionLayoutListConfiguration support**: `separatorColor`, `backgroundColor`, `headerTopPadding` across all list types with `separatorHandler` for per-item separator customization.
+- **Header/footer configuration**: `headerMode`/`footerMode` and `headerContentProvider`/`footerContentProvider` on `GroupedList`.
+- **Selection APIs**: `allowsMultipleSelection`, `allowsSelectionDuringEditing`, `allowsMultipleSelectionDuringEditing`, and `isEditing` computed property on all list types.
+- **Navigation APIs**: `itemIdentifier(for:)`, `indexPath(for:)`, and `scrollToItem(_:)` on all list configurations.
+- **`GroupedList.setSections` with `SnapshotBuilder` DSL** for declarative section updates.
+- **`ListLayout` factory methods** for all compositional layout appearance styles.
+- **`dismantleUIView`** added to all SwiftUI wrappers for deterministic cleanup.
+- **`buildLimitedAvailability`** added to all four result builders.
+- **`withTaskCancellationHandler`** support to propagate cancellation from structured parent tasks during SwiftUI coordinator teardown.
+
+### Changed
+
+- **`SectionModel` `Item` constraint** relaxed to `Hashable & Sendable`, fixing inline-content convenience initializers for plain data types.
+- **`SwipeActionBridge` renamed to `ListConfigurationBridge`**: Centralizes shared delegate logic, item navigation, and scroll-to-item into a single bridge to eliminate duplication across list types.
+- **Rapid-render coalescing**: New updates now cancel previous pending applies for faster UI convergence.
+- **UIKit layout closures** wrapped in `MainActor.assumeIsolated` for Swift 6 strict concurrency readiness.
+- **`OutlineList.setItems`** now uses native section snapshot apply instead of flat snapshot rebuild, enabling UIKit's optimized subtree diffing and native expand/collapse animations.
+
+### Fixed
+
+- **Section snapshot parent map corruption**: Fixed `snapshot(of:includingParent:)` where dangling parent references were copied for extracted subtrees.
+- **Multi-selection**: Guard `deselectItem` behind `!allowsMultipleSelection` so multi-selection workflows function correctly.
+- **Snapshot/UI mismatch**: Serialized `applySnapshotUsingReloadData` through the apply task chain to prevent interleaving with animated applies.
+- **Stale snapshot on deallocation**: Always update `currentSnapshot` before the `guard` when `collectionView` is deallocated.
+- **GroupedList header/footer atomicity**: Use merge-then-trim pattern during animated transitions.
+- **Snapshot data loss in move operation**: Validate destination section bounds before deleting item in `moveItemAt`.
+- **`deinit` task cancellation** added to `SimpleList`, `GroupedList`, and `OutlineList` to cancel lingering tasks on deallocation.
+- **Refresh control cleanup**: Use `defer` in `handleRefresh` to ensure `refreshTask` cleanup and spinner dismissal run on all exit paths.
+
+### Performance
+
+- **LIS-based minimal move detection**: Replaced naive diff move detection with longest-increasing-subsequence algorithm using O(n log n) patience sorting, eliminating unnecessary batch update animations.
+
 ## [0.1.0] - 2026-02-13
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds retroactive changelog entries for releases **0.2.0**, **0.3.0**, and **0.4.0** using the [Keep a Changelog](https://keepachangelog.com/) format
- Entries were reconstructed from commit messages, PR descriptions, and tag history
- Existing 0.0.1 and 0.1.0 entries are unchanged

### Highlights by release

**0.4.0** — 5 new `ListAccessory` cases (toggle, badge, image, progress, activityIndicator)

**0.3.0** — Scroll view delegate forwarding, `selfSizingInvalidation`, chat example

**0.2.0** — Largest release: UICollectionLayoutListConfiguration support, onDelete/onMove/onDeselect callbacks, LIS-based move optimization, stability fixes for snapshot corruption, and 4 new accessory types

## Test plan

- [ ] Review changelog entries against the [releases](https://github.com/Iron-Ham/Lists/tags) and merged PRs for accuracy
- [ ] Verify formatting renders correctly on GitHub