### PR TITLE
Add pre-commit documentation check to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,16 @@ Agents are **encouraged** to create and update `AGENTS.md` files as they learn a
 3. Keep instructions factual, concise, and specific to the directory's scope
 4. Update instructions when code patterns change (e.g., new conventions, renamed types)
 5. Don't duplicate information from parent `AGENTS.md` — child files inherit parent context
+
+### Pre-Commit Documentation Check
+
+**Before every commit**, pause and ask yourself:
+
+> *Have I learned something new about this codebase — a convention, a gotcha, an architectural decision, a non-obvious dependency — that isn't already captured in an `AGENTS.md` file?*
+
+If yes:
+- **Update** the nearest relevant `AGENTS.md` with the new information
+- **Create** a new `AGENTS.md` (+ `CLAUDE.md` symlink) in the directory where the knowledge is most scoped, if no suitable file exists yet
+- Include the documentation update in the same commit as the code change
+
+This ensures institutional knowledge grows naturally alongside the code, rather than being lost between sessions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **AGENTS.md pre-commit documentation check**: Agents are now prompted to reflect on whether they've discovered new codebase knowledge before every commit, and to update or create `AGENTS.md` files accordingly.
+
 ## [0.4.0] - 2026-02-15
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds a "Pre-Commit Documentation Check" subsection to the root `AGENTS.md` that prompts agents to reflect before every commit on whether they've discovered new codebase knowledge worth documenting
- If new knowledge is found, agents should update the nearest `AGENTS.md` or create a new one — in the same commit as the code change

## Test plan

- [ ] Verify the new section renders correctly in the `AGENTS.md` markdown
- [ ] Confirm `CLAUDE.md` symlink still resolves properly