### PR TITLE
Require agents to regenerate docs for public API changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,18 @@ When submitting a PR:
 3. Write a concise, user-facing description of the change
 4. PRs without a changelog entry should not be merged
 
+## Documentation
+
+The project uses **DocC** to generate API documentation, hosted as static files in the `docs/` directory (checked into the repo). Run `make docs` to regenerate.
+
+**You MUST run `make docs`** and commit the updated `docs/` output when any of the following change:
+
+- **Public API** in `Sources/ListKit/` or `Sources/Lists/` — adding, removing, or renaming any `public` type, method, property, or protocol requirement
+- **Doc comments** (`///`) on public symbols
+- **DocC catalog content** — anything under `Sources/ListKit/ListKit.docc/` or `Sources/Lists/Lists.docc/` (articles, tutorials, media, symbol extensions)
+
+If unsure whether your change affects generated docs, run `make docs` and check `git diff docs/` — if there are changes, include them in the commit.
+
 ## Key Conventions
 
 - **`CellViewModel` protocol** is the core abstraction in Lists. Requires `Hashable` + `Sendable`. Optionally conform to `Identifiable` to get free `Hashable`/`Equatable` from `id`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **AGENTS.md pre-commit documentation check**: Agents are now prompted to reflect on whether they've discovered new codebase knowledge before every commit, and to update or create `AGENTS.md` files accordingly.
+- **AGENTS.md**: Agents must now run `make docs` when modifying public API, doc comments, or DocC catalog content
 
 ## [0.4.0] - 2026-02-15
 

--- a/Sources/ListKit/AGENTS.md
+++ b/Sources/ListKit/AGENTS.md
@@ -64,3 +64,4 @@ Do not merge changes that regress benchmark numbers without explicit approval.
 - `CollectionViewDiffableDataSource` must remain API-compatible with Apple's `UICollectionViewDiffableDataSource`
 - Run `make test-listkit` to verify correctness
 - Run `make benchmark` to verify performance (see Performance section above)
+- Run `make docs` if you changed any public API, doc comments (`///`), or files under `ListKit.docc/` — commit the updated `docs/` output

--- a/Sources/Lists/AGENTS.md
+++ b/Sources/Lists/AGENTS.md
@@ -96,3 +96,4 @@ SwiftUI wrappers use `UIViewRepresentable`. The `SwiftUICellViewModel` protocol 
 - SwiftUI wrappers must call `updateUIView` correctly (avoid unnecessary reloads)
 - All configurations are `@MainActor` — don't break actor isolation
 - Run `make test-lists` to verify changes
+- Run `make docs` if you changed any public API, doc comments (`///`), or files under `Lists.docc/` — commit the updated `docs/` output


### PR DESCRIPTION
## Summary
- Adds a **Documentation** section to the root `AGENTS.md` requiring agents to run `make docs` when modifying public API, doc comments (`///`), or DocC catalog content in either module
- Adds doc regeneration reminders to the "When Modifying This Module" checklist in both `Sources/ListKit/AGENTS.md` and `Sources/Lists/AGENTS.md`
- Includes a fallback heuristic: run `make docs` and check `git diff docs/` when unsure

## Test plan
- [x] Verify the new Documentation section appears in root `AGENTS.md` between Changelog and Key Conventions
- [x] Verify `Sources/ListKit/AGENTS.md` has the `make docs` bullet in "When Modifying This Module"
- [x] Verify `Sources/Lists/AGENTS.md` has the `make docs` bullet in "When Modifying This Module"
- [x] Changelog entry added under `[Unreleased]`