### PR TITLE
Remove separators from ListsChatExampleViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`SnapshotSection` header/footer support**: `header` and `footer` optional parameters in the `SnapshotBuilder` DSL, wired through to `GroupedList.setSections`.
 - **`Snapshot.contains(_:)` and `contains(section:)`**: Convenience queries using the reverse map for O(1) lookups when available.
 
+### Fixed
+
+- **Chat example separators**: Added explicit `separatorHandler` to `ListsChatExampleViewController` to ensure separators are fully hidden, preventing `itemSeparatorHandler` from overriding `showsSeparators: false`.
+
 ### Changed
 
 - **AGENTS.md pre-commit documentation check**: Agents are now prompted to reflect on whether they've discovered new codebase knowledge before every commit, and to update or create `AGENTS.md` files accordingly.

--- a/Example/Sources/ListsChatExampleViewController.swift
+++ b/Example/Sources/ListsChatExampleViewController.swift
@@ -67,6 +67,13 @@ final class ListsChatExampleViewController: UIViewController {
     )
     list.scrollViewDelegate = store
 
+    list.separatorHandler = { _, config in
+      var config = config
+      config.topSeparatorVisibility = .hidden
+      config.bottomSeparatorVisibility = .hidden
+      return config
+    }
+
     list.contextMenuProvider = { item in
       UIContextMenuConfiguration(actionProvider: { _ in
         UIMenu(children: [


### PR DESCRIPTION
## Summary
- Adds an explicit `separatorHandler` to `ListsChatExampleViewController` that hides both top and bottom separators for every cell
- Prevents the `itemSeparatorHandler` registered by `ListConfigurationBridge` from overriding `showsSeparators: false`

## Test plan
- [ ] Run the Example app and navigate to the "Chat Lists" tab
- [ ] Verify no separator lines appear between chat bubbles
- [ ] Send messages and confirm separators remain hidden during streaming