### PR TITLE
Add missing example coverage for new API features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING: SwiftUI view initializers simplified**: `SimpleListView`, `GroupedListView`, and `OutlineListView` CellViewModel-based initializers now accept only layout/structural parameters. Behavioral properties (`onSelect`, `onDelete`, `onRefresh`, `editing`, etc.) must be set via the new chainable modifiers. Inline content initializers retain item-typed behavioral params (e.g., `onSelect`, `onDelete`) since they perform `Data → Item` wrapping.
 - **Refresh control logic consolidated**: Extracted `RefreshControlManager` to replace triplicated refresh control code across `SimpleList`, `GroupedList`, and `OutlineList`.
 - **Example app updated**: All UIKit examples use `ListCellViewModel` and `setListContent()`. `OutlineExampleViewController` uses builder DSL. `SwiftUIWrappersExampleView` demonstrates modifier-based configuration. `LiveExampleViewController` uses `ContentEquatable` for automatic reconfiguration.
+- **Example app: expanded feature coverage**: DSL example uses `GroupedList` with `SnapshotSection` header/footer DSL and `Snapshot.contains(section:)`. GroupedList example demonstrates `@ItemsBuilder`, `ListAccessory.toggle`, `.progress`, and `.activityIndicator`. All three UIKit examples include pull-to-refresh. SwiftUI `GroupedDemoView` demonstrates `.editing` and `.allowsMultipleSelection` modifiers.
 
 ### Fixed
 

--- a/Example/AGENTS.md
+++ b/Example/AGENTS.md
@@ -15,7 +15,7 @@ Example/
     ├── AppDelegate.swift                — App lifecycle
     ├── SceneDelegate.swift              — Window setup with tab bar
     ├── ListKitExampleViewController.swift    — Raw ListKit API usage
-    ├── DSLExampleViewController.swift        — ListDataSource with DSL
+    ├── DSLExampleViewController.swift        — GroupedList with SnapshotBuilder DSL
     ├── LiveExampleViewController.swift       — Real-time updates demo
     ├── GroupedListExampleViewController.swift — Multi-section grouped list
     ├── OutlineExampleViewController.swift    — Hierarchical expand/collapse

--- a/Example/Sources/SwiftUIWrappersExampleView.swift
+++ b/Example/Sources/SwiftUIWrappersExampleView.swift
@@ -155,6 +155,8 @@ private struct GroupedDemoView: View {
         ),
       ]
     )
+    .editing(isEditing)
+    .allowsMultipleSelection(isEditing)
     .onSelect { item in
       print("Selected: \(item.name)")
     }
@@ -187,16 +189,25 @@ private struct GroupedDemoView: View {
       frameworks.shuffle()
     }
     .overlay(alignment: .bottom) {
-      Button("Shuffle") {
-        languages.shuffle()
-        frameworks.shuffle()
+      HStack(spacing: 12) {
+        Button(isEditing ? "Done" : "Edit") {
+          isEditing.toggle()
+        }
+        .buttonStyle(.borderedProminent)
+
+        Button("Shuffle") {
+          languages.shuffle()
+          frameworks.shuffle()
+        }
+        .buttonStyle(.bordered)
       }
-      .buttonStyle(.borderedProminent)
       .padding()
     }
   }
 
   // MARK: Private
+
+  @State private var isEditing = false
 
   @State private var languages = [
     LanguageItem(name: "Swift", year: 2014),


### PR DESCRIPTION
## Summary

- **DSLExampleViewController**: Switched from raw `ListDataSource` + manual headers to `GroupedList` with `SnapshotSection` header/footer DSL, added pull-to-refresh, and demonstrated `Snapshot.contains(section:)` for section querying
- **GroupedListExampleViewController**: Added `ListAccessory.toggle`, `.progress`, and `.activityIndicator` demos via a new `AccessoryStyle` enum; switched to `@ItemsBuilder` init for `SectionModel`; added pull-to-refresh; extracted shared `sectionModels` computed property
- **OutlineExampleViewController**: Added pull-to-refresh that shuffles children within folders; extracted `shuffleChildren` as a reusable method
- **SwiftUIWrappersExampleView**: Added `.editing(isEditing)` and `.allowsMultipleSelection(isEditing)` modifiers to `GroupedDemoView` with an Edit/Done toggle button

## Feature coverage after this PR

| Feature | Where Demonstrated |
|---------|-------------------|
| SnapshotSection header/footer DSL | DSLExampleViewController |
| UIKit pull-to-refresh | DSLExample, GroupedListExample, OutlineExample |
| Snapshot.contains(section:) | DSLExampleViewController |
| ListAccessory.toggle | GroupedListExampleViewController |
| ListAccessory.progress | GroupedListExampleViewController |
| ListAccessory.activityIndicator | GroupedListExampleViewController |
| SectionModel @ItemsBuilder | GroupedListExampleViewController |
| .editing modifier | SwiftUIWrappersExampleView (GroupedDemoView) |
| .allowsMultipleSelection modifier | SwiftUIWrappersExampleView (GroupedDemoView) |

## Test plan

- [x] `make build` — frameworks compile
- [x] `make format` — code style compliant (pre-commit hook passes)
- [x] `make test` — all 262 tests pass
- [x] Example app compiles (only pre-existing `ChatExampleView.swift` errors unrelated to this PR)
- [ ] Visual: each example demonstrates its added features when run in the simulator