### PR TITLE
Add API ergonomics improvements and missing query properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Snapshot `Equatable` conformance**: `DiffableDataSourceSnapshot` now conforms to `Equatable`, comparing section identifiers and item arrays while ignoring transient reload/reconfigure markers.
+- **Snapshot `init(sections:)` convenience initializer**: Build snapshots from `[(SectionID, [ItemID])]` pairs in a single call.
+- **`sectionIdentifier(at:)` on `DiffableDataSourceSnapshot`**: Index-based section lookup, complementing the existing `index(ofSection:)`.
+- **`replaceItems(in:with:)` on `DiffableDataSourceSnapshot`**: Bulk-replace all items in a section without deleting/re-appending the section.
+- **`removeItems(where:)` on `DiffableDataSourceSnapshot`**: Remove items matching a predicate across all sections, following `removeAll(where:)` convention.
+- **`children(of:)` on `DiffableDataSourceSectionSnapshot`**: Returns direct children of a given item, complementing the existing `parent(of:)`.
+- **Programmatic selection**: `selectItem(_:at:animated:)`, `deselectItem(_:animated:)`, and `isSelected(_:)` on `SimpleList`, `GroupedList`, and `OutlineList`.
+- **`shouldSelect` handler**: Closure on all three configurations (+ SwiftUI modifiers) that gates item selection via the `collectionView(_:shouldSelectItemAt:)` delegate.
+- **`backgroundView` property**: Auto-visibility empty-state view on all three configurations (+ SwiftUI modifiers), shown when the list is empty and hidden when it has content.
+- **`canMoveItemProvider`**: Per-item reorder predicate on `SimpleList` and `GroupedList` (+ SwiftUI modifiers).
+- **`scrollToTop` / `scrollToBottom`**: Convenience scroll methods on all three configurations.
+- **OutlineList tree queries**: `allItems`, `visibleItems`, `rootItems`, `parent(of:)`, and `level(of:)` for inspecting the outline hierarchy.
+- **`SimpleList.items`**: Convenience accessor for the current items in the list.
+- **Snapshot type aliases**: `SimpleList.Snapshot`, `GroupedList.Snapshot`, `OutlineList.Snapshot` for ergonomic snapshot type references.
 - **`MixedSection` header/footer support**: Optional `header` and `footer` parameters on `MixedSection`, wired through `MixedListDataSource.apply(content:)` with `headerForSection(_:)`/`footerForSection(_:)` accessors and a `configureListHeaderFooterProvider()` convenience method for automatic supplementary view rendering.
 - **`MixedListDataSource` reorder support**: `canMoveItemHandler` and `didMoveItemHandler` properties for drag-and-drop reordering parity with `ListDataSource`.
 - **Section query methods on `GroupedList`**: `sectionIdentifier(for:)`, `index(for:)`, and `items(in:)` for section-level navigation.

--- a/Sources/ListKit/Snapshot/DiffableDataSourceSectionSnapshot.swift
+++ b/Sources/ListKit/Snapshot/DiffableDataSourceSectionSnapshot.swift
@@ -161,6 +161,11 @@ public struct DiffableDataSourceSectionSnapshot<ItemIdentifierType: Hashable & S
     parentMap[item]
   }
 
+  /// Returns the direct children of the specified item, or an empty array if it has none.
+  public func children(of item: ItemIdentifierType) -> [ItemIdentifierType] {
+    childrenMap[item] ?? []
+  }
+
   /// Returns a new section snapshot containing only the subtree rooted at the specified item.
   public func snapshot(of item: ItemIdentifierType, includingParent: Bool = false) -> DiffableDataSourceSectionSnapshot {
     var newSnapshot = DiffableDataSourceSectionSnapshot()

--- a/Sources/Lists/Configurations/ListConfigurationBridge.swift
+++ b/Sources/Lists/Configurations/ListConfigurationBridge.swift
@@ -146,6 +146,70 @@ final class ListConfigurationBridge<SectionID: Hashable & Sendable, Item: CellVi
     return true
   }
 
+  /// Programmatically selects the specified item.
+  ///
+  /// - Returns: `true` if the item was found and selected, `false` if not present.
+  @discardableResult
+  func selectItem(
+    _ item: Item,
+    in collectionView: UICollectionView,
+    at scrollPosition: UICollectionView.ScrollPosition = [],
+    animated: Bool = true
+  ) -> Bool {
+    guard let indexPath = dataSource?.indexPath(for: item) else { return false }
+    collectionView.selectItem(at: indexPath, animated: animated, scrollPosition: scrollPosition)
+    return true
+  }
+
+  /// Programmatically deselects the specified item.
+  ///
+  /// - Returns: `true` if the item was found and deselected, `false` if not present.
+  @discardableResult
+  func deselectItem(
+    _ item: Item,
+    in collectionView: UICollectionView,
+    animated: Bool = true
+  ) -> Bool {
+    guard let indexPath = dataSource?.indexPath(for: item) else { return false }
+    collectionView.deselectItem(at: indexPath, animated: animated)
+    return true
+  }
+
+  /// Returns whether the specified item is currently selected.
+  func isSelected(_ item: Item, in collectionView: UICollectionView) -> Bool {
+    guard let indexPath = dataSource?.indexPath(for: item) else { return false }
+    return collectionView.indexPathsForSelectedItems?.contains(indexPath) ?? false
+  }
+
+  /// Handles a `shouldSelectItemAt` delegate call.
+  func handleShouldSelect(
+    at indexPath: IndexPath,
+    shouldSelect: (@MainActor (Item) -> Bool)?
+  ) -> Bool {
+    guard let shouldSelect else { return true }
+    guard let item = dataSource?.itemIdentifier(for: indexPath) else {
+      assertionFailure("Item not found for indexPath \(indexPath)")
+      return true
+    }
+    return shouldSelect(item)
+  }
+
+  /// Scrolls to the top of the collection view.
+  func scrollToTop(in collectionView: UICollectionView, animated: Bool) {
+    let topOffset = CGPoint(x: 0, y: -collectionView.adjustedContentInset.top)
+    collectionView.setContentOffset(topOffset, animated: animated)
+  }
+
+  /// Scrolls to the bottom of the collection view.
+  func scrollToBottom(in collectionView: UICollectionView, animated: Bool) {
+    let contentHeight = collectionView.contentSize.height
+    let frameHeight = collectionView.bounds.height
+    let bottomInset = collectionView.adjustedContentInset.bottom
+    guard contentHeight > frameHeight else { return }
+    let bottomOffset = CGPoint(x: 0, y: contentHeight - frameHeight + bottomInset)
+    collectionView.setContentOffset(bottomOffset, animated: animated)
+  }
+
   /// Resolves the separator configuration for an item.
   ///
   /// Uses optional chaining for `dataSource` rather than `assertionFailure` because

--- a/Sources/Lists/SwiftUI/GroupedListView+Modifiers.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView+Modifiers.swift
@@ -156,4 +156,34 @@ extension GroupedListView {
     copy.scrollViewDelegate = delegate
     return copy
   }
+
+  /// Sets a closure that determines whether an item should be selectable.
+  ///
+  /// Return `false` to prevent the item from being selected.
+  public func shouldSelect(_ handler: @escaping @MainActor (Item) -> Bool) -> Self {
+    var copy = self
+    copy.shouldSelect = handler
+    return copy
+  }
+
+  /// Sets a view displayed behind the list content.
+  ///
+  /// The view is automatically shown when the list is empty and hidden when it has content.
+  public func backgroundView(_ view: UIView) -> Self {
+    var copy = self
+    copy.backgroundView = view
+    return copy
+  }
+
+  /// Sets a closure that determines whether a specific item can be reordered.
+  ///
+  /// When set alongside ``onMove(_:)``, this is called for each item when drag begins.
+  /// Return `false` to prevent an item from being dragged.
+  public func canMoveItem(
+    _ provider: @escaping @MainActor (Item) -> Bool
+  ) -> Self {
+    var copy = self
+    copy.canMoveItemProvider = provider
+    return copy
+  }
 }

--- a/Sources/Lists/SwiftUI/GroupedListView.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView.swift
@@ -146,6 +146,8 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
   public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
   /// Closure that returns a context menu configuration for a given item.
   public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+  /// Optional closure called before an item is selected. Return `false` to prevent selection.
+  public var shouldSelect: (@MainActor (Item) -> Bool)?
   /// Per-item separator customization handler.
   public var separatorHandler: (@MainActor (Item, UIListSeparatorConfiguration) -> UIListSeparatorConfiguration)?
   /// Closure that returns a custom content configuration for a section header.
@@ -160,6 +162,10 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
   /// Called once when the underlying `UICollectionView` is created. Use this to store a reference
   /// for direct UIKit access (e.g. animated layout invalidation).
   public var collectionViewHandler: (@MainActor (UICollectionView) -> Void)?
+  /// A view displayed behind the list content, automatically shown when the list is empty.
+  public var backgroundView: UIView?
+  /// Optional closure that determines whether a specific item can be reordered.
+  public var canMoveItemProvider: (@MainActor (Item) -> Bool)?
   /// An optional delegate that receives `UIScrollViewDelegate` callbacks from the underlying
   /// collection view's scroll view.
   public var scrollViewDelegate: UIScrollViewDelegate?
@@ -186,10 +192,13 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
     list.contextMenuProvider = contextMenuProvider
+    list.shouldSelect = shouldSelect
     list.separatorHandler = separatorHandler
     list.headerContentProvider = headerContentProvider
     list.footerContentProvider = footerContentProvider
     list.onMove = onMove
+    list.canMoveItemProvider = canMoveItemProvider
+    list.backgroundView = backgroundView
     list.scrollViewDelegate = scrollViewDelegate
     list.allowsMultipleSelection = allowsMultipleSelection
     list.allowsSelectionDuringEditing = allowsSelectionDuringEditing
@@ -232,10 +241,13 @@ public struct GroupedListView<SectionID: Hashable & Sendable, Item: CellViewMode
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
     list.contextMenuProvider = contextMenuProvider
+    list.shouldSelect = shouldSelect
     list.separatorHandler = separatorHandler
     list.headerContentProvider = headerContentProvider
     list.footerContentProvider = footerContentProvider
     list.onMove = onMove
+    list.canMoveItemProvider = canMoveItemProvider
+    list.backgroundView = backgroundView
     list.scrollViewDelegate = scrollViewDelegate
     list.allowsMultipleSelection = allowsMultipleSelection
     list.allowsSelectionDuringEditing = allowsSelectionDuringEditing

--- a/Sources/Lists/SwiftUI/OutlineListView+Modifiers.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView+Modifiers.swift
@@ -125,4 +125,22 @@ extension OutlineListView {
     copy.scrollViewDelegate = delegate
     return copy
   }
+
+  /// Sets a closure that determines whether an item should be selectable.
+  ///
+  /// Return `false` to prevent the item from being selected.
+  public func shouldSelect(_ handler: @escaping @MainActor (Item) -> Bool) -> Self {
+    var copy = self
+    copy.shouldSelect = handler
+    return copy
+  }
+
+  /// Sets a view displayed behind the list content.
+  ///
+  /// The view is automatically shown when the list is empty and hidden when it has content.
+  public func backgroundView(_ view: UIView) -> Self {
+    var copy = self
+    copy.backgroundView = view
+    return copy
+  }
 }

--- a/Sources/Lists/SwiftUI/OutlineListView.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView.swift
@@ -129,6 +129,8 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
   public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
   /// Closure that returns a context menu configuration for a given item.
   public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+  /// Optional closure called before an item is selected. Return `false` to prevent selection.
+  public var shouldSelect: (@MainActor (Item) -> Bool)?
   /// Per-item separator customization handler.
   public var separatorHandler: (@MainActor (Item, UIListSeparatorConfiguration) -> UIListSeparatorConfiguration)?
   /// An async closure invoked on pull-to-refresh.
@@ -136,6 +138,8 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
   /// Called once when the underlying `UICollectionView` is created. Use this to store a reference
   /// for direct UIKit access (e.g. animated layout invalidation).
   public var collectionViewHandler: (@MainActor (UICollectionView) -> Void)?
+  /// A view displayed behind the list content, automatically shown when the list is empty.
+  public var backgroundView: UIView?
   /// An optional delegate that receives `UIScrollViewDelegate` callbacks from the underlying
   /// collection view's scroll view.
   public var scrollViewDelegate: UIScrollViewDelegate?
@@ -160,7 +164,9 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
     list.contextMenuProvider = contextMenuProvider
+    list.shouldSelect = shouldSelect
     list.separatorHandler = separatorHandler
+    list.backgroundView = backgroundView
     list.scrollViewDelegate = scrollViewDelegate
     list.allowsMultipleSelection = allowsMultipleSelection
     list.allowsSelectionDuringEditing = allowsSelectionDuringEditing
@@ -201,7 +207,9 @@ public struct OutlineListView<Item: CellViewModel>: UIViewRepresentable {
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
     list.contextMenuProvider = contextMenuProvider
+    list.shouldSelect = shouldSelect
     list.separatorHandler = separatorHandler
+    list.backgroundView = backgroundView
     list.scrollViewDelegate = scrollViewDelegate
     list.allowsMultipleSelection = allowsMultipleSelection
     list.allowsSelectionDuringEditing = allowsSelectionDuringEditing

--- a/Sources/Lists/SwiftUI/SimpleListView+Modifiers.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView+Modifiers.swift
@@ -138,4 +138,34 @@ extension SimpleListView {
     copy.scrollViewDelegate = delegate
     return copy
   }
+
+  /// Sets a closure that determines whether an item should be selectable.
+  ///
+  /// Return `false` to prevent the item from being selected.
+  public func shouldSelect(_ handler: @escaping @MainActor (Item) -> Bool) -> Self {
+    var copy = self
+    copy.shouldSelect = handler
+    return copy
+  }
+
+  /// Sets a view displayed behind the list content.
+  ///
+  /// The view is automatically shown when the list is empty and hidden when it has content.
+  public func backgroundView(_ view: UIView) -> Self {
+    var copy = self
+    copy.backgroundView = view
+    return copy
+  }
+
+  /// Sets a closure that determines whether a specific item can be reordered.
+  ///
+  /// When set alongside ``onMove(_:)``, this is called for each item when drag begins.
+  /// Return `false` to prevent an item from being dragged.
+  public func canMoveItem(
+    _ provider: @escaping @MainActor (Item) -> Bool
+  ) -> Self {
+    var copy = self
+    copy.canMoveItemProvider = provider
+    return copy
+  }
 }

--- a/Sources/Lists/SwiftUI/SimpleListView.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView.swift
@@ -141,6 +141,8 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
   public var leadingSwipeActionsProvider: (@MainActor (Item) -> UISwipeActionsConfiguration?)?
   /// Closure that returns a context menu configuration for a given item.
   public var contextMenuProvider: (@MainActor (Item) -> UIContextMenuConfiguration?)?
+  /// Optional closure called before an item is selected. Return `false` to prevent selection.
+  public var shouldSelect: (@MainActor (Item) -> Bool)?
   /// Per-item separator customization handler.
   public var separatorHandler: (@MainActor (Item, UIListSeparatorConfiguration) -> UIListSeparatorConfiguration)?
   /// An async closure invoked on pull-to-refresh. The refresh control is dismissed when the closure returns.
@@ -151,6 +153,10 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
   /// Called once when the underlying `UICollectionView` is created. Use this to store a reference
   /// for direct UIKit access (e.g. animated layout invalidation).
   public var collectionViewHandler: (@MainActor (UICollectionView) -> Void)?
+  /// A view displayed behind the list content, automatically shown when the list is empty.
+  public var backgroundView: UIView?
+  /// Optional closure that determines whether a specific item can be reordered.
+  public var canMoveItemProvider: (@MainActor (Item) -> Bool)?
   /// An optional delegate that receives `UIScrollViewDelegate` callbacks from the underlying
   /// collection view's scroll view.
   public var scrollViewDelegate: UIScrollViewDelegate?
@@ -176,8 +182,11 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
     list.contextMenuProvider = contextMenuProvider
+    list.shouldSelect = shouldSelect
     list.separatorHandler = separatorHandler
     list.onMove = onMove
+    list.canMoveItemProvider = canMoveItemProvider
+    list.backgroundView = backgroundView
     list.scrollViewDelegate = scrollViewDelegate
     list.allowsMultipleSelection = allowsMultipleSelection
     list.allowsSelectionDuringEditing = allowsSelectionDuringEditing
@@ -219,8 +228,11 @@ public struct SimpleListView<Item: CellViewModel>: UIViewRepresentable {
     list.trailingSwipeActionsProvider = trailingSwipeActionsProvider
     list.leadingSwipeActionsProvider = leadingSwipeActionsProvider
     list.contextMenuProvider = contextMenuProvider
+    list.shouldSelect = shouldSelect
     list.separatorHandler = separatorHandler
     list.onMove = onMove
+    list.canMoveItemProvider = canMoveItemProvider
+    list.backgroundView = backgroundView
     list.scrollViewDelegate = scrollViewDelegate
     list.allowsMultipleSelection = allowsMultipleSelection
     list.allowsSelectionDuringEditing = allowsSelectionDuringEditing

--- a/Tests/ListKitTests/SectionSnapshotTests.swift
+++ b/Tests/ListKitTests/SectionSnapshotTests.swift
@@ -230,4 +230,23 @@ struct SectionSnapshotTests {
     let snapshot = DiffableDataSourceSectionSnapshot<String>()
     let _: any Sendable = snapshot
   }
+
+  @Test
+  func childrenOfParent() {
+    var snapshot = DiffableDataSourceSectionSnapshot<String>()
+    snapshot.append(["A"])
+    snapshot.append(["A1", "A2"], to: "A")
+    snapshot.append(["A1a"], to: "A1")
+
+    #expect(snapshot.children(of: "A") == ["A1", "A2"])
+    #expect(snapshot.children(of: "A1") == ["A1a"])
+    #expect(snapshot.children(of: "A2").isEmpty)
+    #expect(snapshot.children(of: "A1a").isEmpty)
+  }
+
+  @Test
+  func childrenOfNonexistentItem() {
+    let snapshot = DiffableDataSourceSectionSnapshot<String>()
+    #expect(snapshot.children(of: "missing").isEmpty)
+  }
 }

--- a/Tests/ListsTests/SimpleListTests.swift
+++ b/Tests/ListsTests/SimpleListTests.swift
@@ -255,4 +255,73 @@ struct SimpleListTests {
     list.deselectAll(animated: false)
     #expect((list.collectionView.indexPathsForSelectedItems ?? []).isEmpty)
   }
+
+  @Test
+  func selectItemProgrammatically() async {
+    let list = SimpleList<TextItem>()
+    let a = TextItem(text: "A")
+    let b = TextItem(text: "B")
+    await list.setItems([a, b], animatingDifferences: false)
+
+    let result = list.selectItem(a, animated: false)
+    #expect(result == true)
+    #expect(list.selectedItems == [a])
+  }
+
+  @Test
+  func selectItemReturnsFalseForMissing() async {
+    let list = SimpleList<TextItem>()
+    await list.setItems([TextItem(text: "A")], animatingDifferences: false)
+
+    let missing = TextItem(text: "Missing")
+    let result = list.selectItem(missing, animated: false)
+    #expect(result == false)
+    #expect(list.selectedItems.isEmpty)
+  }
+
+  @Test
+  func deselectItemProgrammatically() async {
+    let list = SimpleList<TextItem>()
+    let a = TextItem(text: "A")
+    await list.setItems([a], animatingDifferences: false)
+
+    list.selectItem(a, animated: false)
+    #expect(list.isSelected(a) == true)
+
+    let result = list.deselectItem(a, animated: false)
+    #expect(result == true)
+    #expect(list.isSelected(a) == false)
+  }
+
+  @Test
+  func shouldSelectPreventsSelection() async {
+    let list = SimpleList<TextItem>()
+    let a = TextItem(text: "A")
+    let b = TextItem(text: "B")
+    await list.setItems([a, b], animatingDifferences: false)
+
+    list.shouldSelect = { item in item != a }
+
+    let shouldSelectA = list.collectionView(list.collectionView, shouldSelectItemAt: IndexPath(item: 0, section: 0))
+    let shouldSelectB = list.collectionView(list.collectionView, shouldSelectItemAt: IndexPath(item: 1, section: 0))
+
+    #expect(shouldSelectA == false)
+    #expect(shouldSelectB == true)
+  }
+
+  @Test
+  func shouldSelectDefaultsToTrue() async {
+    let list = SimpleList<TextItem>()
+    let a = TextItem(text: "A")
+    await list.setItems([a], animatingDifferences: false)
+
+    let result = list.collectionView(list.collectionView, shouldSelectItemAt: IndexPath(item: 0, section: 0))
+    #expect(result == true)
+  }
+
+  @Test
+  func snapshotTypeAlias() {
+    // Verify the type alias compiles and resolves correctly
+    let _: SimpleList<TextItem>.Snapshot = DiffableDataSourceSnapshot<Int, TextItem>()
+  }
 }


### PR DESCRIPTION
## Summary

- **Snapshot `Equatable` conformance**: Compare sections + items, ignoring transient reload/reconfigure markers
- **Snapshot `init(sections:)`**: Build snapshots from `[(SectionID, [ItemID])]` pairs in a single call
- **`sectionIdentifier(at:)`**: Index-based section lookup on `DiffableDataSourceSnapshot`
- **`replaceItems(in:with:)`**: Bulk-replace all items in a section without deleting/re-appending
- **`filterItems(_:)`**: Remove items matching a predicate across all sections
- **`children(of:)`**: Returns direct children of a given item on `DiffableDataSourceSectionSnapshot`
- **Programmatic selection**: `selectItem`, `deselectItem`, `isSelected` on all three configurations via bridge
- **`shouldSelect` handler**: Closure on all three configurations + SwiftUI modifiers gating item selection
- **`backgroundView`**: Auto-visibility empty-state view on all three configurations + SwiftUI modifiers
- **`canMoveItemProvider`**: Per-item reorder predicate on `SimpleList` + `GroupedList` + SwiftUI modifiers
- **`scrollToTop` / `scrollToBottom`**: Convenience scroll methods on all three configurations
- **OutlineList tree queries**: `allItems`, `visibleItems`, `rootItems`, `parent(of:)`, `level(of:)`
- **`SimpleList.items`**: Convenience accessor for current items
- **Snapshot type aliases**: `SimpleList.Snapshot`, `GroupedList.Snapshot`, `OutlineList.Snapshot`

## Test plan

- [x] 14 new snapshot tests (Equatable, convenience init, sectionIdentifier(at:), replaceItems, filterItems)
- [x] 2 new section snapshot tests (children(of:))
- [x] 6 new SimpleList tests (programmatic selection, shouldSelect, type alias)
- [x] All 177 ListKit tests pass
- [x] All 87 Lists tests pass
- [x] `make format` and `make lint` pass with zero violations
- [x] `make build` succeeds for both frameworks