### PR TITLE
Stamp changelog for 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-02-16
+
 ### Added
 
 - **Snapshot `Equatable` conformance**: `DiffableDataSourceSnapshot` now conforms to `Equatable`, comparing section identifiers and item arrays while ignoring transient reload/reconfigure markers.


### PR DESCRIPTION
## Summary

- Stamps the `[Unreleased]` changelog section as `[0.6.0] - 2026-02-16`

## Test plan

- [x] No code changes — changelog only