### PR TITLE
Add // ABOUTME: comments to all Swift files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,18 @@ Tests require an iOS Simulator destination. The Makefile defaults to `iPhone 17 
 
 ## Code Style
 
+- **`// ABOUTME:` comments** — Every `.swift` file must begin with a `// ABOUTME:` comment block (before imports). This is a 1-2 line summary of what the file contains. Format:
+  ```swift
+  // ABOUTME: Short description of this file's purpose.
+  // ABOUTME: Optional second line with additional context.
+  ```
+  Rules:
+  - Place at the very top of the file (line 1), before any `import` statements
+  - Use `// ABOUTME:` prefix on each line (not `///` or `/* */`)
+  - Keep each line under 100 characters
+  - First line: what the file defines or provides
+  - Optional second line: key relationships, constraints, or non-obvious details
+  - When creating or modifying a file, ensure it has an `// ABOUTME:` comment
 - **Swift 6** strict concurrency — all public types must be `Sendable`
 - **SwiftFormat** with Airbnb-based config (see `.swiftformat`)
   - 2-space indentation

--- a/Example/Project.swift
+++ b/Example/Project.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tuist project manifest for the ListKitExample demo app.
+// ABOUTME: Declares a single iOS app target depending on ListKit and Lists.
 import ProjectDescription
 
 let project = Project(

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -1,3 +1,5 @@
+// ABOUTME: App delegate handling launch and scene configuration.
+// ABOUTME: Wires SceneDelegate as the window scene delegate.
 import UIKit
 
 @main

--- a/Example/Sources/ChatExampleView.swift
+++ b/Example/Sources/ChatExampleView.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI chat interface demo using SimpleListView with live-streaming text.
+// ABOUTME: Contains ChatExampleView (the UI) and ChatStore (@Observable data source).
 import Lists
 import SwiftUI
 import UIKit

--- a/Example/Sources/ChatInputBar.swift
+++ b/Example/Sources/ChatInputBar.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Reusable UIKit input bar with a text field and send button.
+// ABOUTME: Shared by the UIKit chat examples (ListKit and Lists variants).
 import UIKit
 
 // MARK: - ChatInputBar

--- a/Example/Sources/ChatShared.swift
+++ b/Example/Sources/ChatShared.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Shared chat types used by all three chat examples.
+// ABOUTME: Defines ChatMessageModel, ChatMessageRef, ChatBubbleView, ChatConversation, and more.
 import Foundation
 import SwiftUI
 import UIKit

--- a/Example/Sources/DSLExampleViewController.swift
+++ b/Example/Sources/DSLExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Demo of @SnapshotBuilder DSL with GroupedList for declarative snapshots.
+// ABOUTME: Shows header/footer support, pull-to-refresh, and snapshot querying.
 import ListKit
 import Lists
 import UIKit

--- a/Example/Sources/GroupedListExampleViewController.swift
+++ b/Example/Sources/GroupedListExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Multi-section grouped list demo using GroupedList with SectionModel.
+// ABOUTME: Showcases swipe actions, selection modes, drag-to-reorder, and pull-to-refresh.
 import Lists
 import UIKit
 

--- a/Example/Sources/ListKitChatExampleViewController.swift
+++ b/Example/Sources/ListKitChatExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Chat UI built with raw CollectionViewDiffableDataSource and pure UIKit cells.
+// ABOUTME: Manually reconfigures cells during streaming via UIContentConfiguration.
 import ListKit
 import SwiftUI
 import UIKit

--- a/Example/Sources/ListKitExampleViewController.swift
+++ b/Example/Sources/ListKitExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Raw ListKit API demo with manual snapshot building.
+// ABOUTME: Shows two-section list with headers, footers, shuffle, add, and drag reorder.
 import ListKit
 import UIKit
 

--- a/Example/Sources/ListsChatExampleViewController.swift
+++ b/Example/Sources/ListsChatExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Chat UI using SimpleList + CellViewModel + UIHostingConfiguration.
+// ABOUTME: @Observable model drives automatic cell updates during streaming.
 import Lists
 import SwiftUI
 import UIKit

--- a/Example/Sources/LiveExampleViewController.swift
+++ b/Example/Sources/LiveExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Timer-driven live-update demo simulating a stock watchlist.
+// ABOUTME: Uses ContentEquatable for automatic cell reconfiguration on price changes.
 import ListKit
 import Lists
 import UIKit

--- a/Example/Sources/MixedExampleViewController.swift
+++ b/Example/Sources/MixedExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Mixed cell types demo using MixedListDataSource with heterogeneous ViewModels.
+// ABOUTME: Combines BannerItem, ProductItem, and RatingItem in separate sections.
 import ListKit
 import Lists
 import UIKit

--- a/Example/Sources/OutlineExampleViewController.swift
+++ b/Example/Sources/OutlineExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Hierarchical expand/collapse demo using OutlineList with a file browser tree.
+// ABOUTME: Uses OutlineItemBuilder DSL and supports swipe actions and pull-to-refresh.
 import Lists
 import UIKit
 

--- a/Example/Sources/SceneDelegate.swift
+++ b/Example/Sources/SceneDelegate.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Scene delegate that sets up the main window with a tab bar controller.
+// ABOUTME: Each tab hosts one example (ListKit, Manual, DSL, Mixed, Outline, SwiftUI, etc.).
 import SwiftUI
 import UIKit
 

--- a/Example/Sources/SwiftUIExampleViewController.swift
+++ b/Example/Sources/SwiftUIExampleViewController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI interop demo rendering CellViewModels via UIHostingConfiguration.
+// ABOUTME: Shows a contact list with SwiftUI-rendered rows in a GroupedList.
 import Lists
 import SwiftUI
 import UIKit

--- a/Example/Sources/SwiftUIWrappersExampleView.swift
+++ b/Example/Sources/SwiftUIWrappersExampleView.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Pure SwiftUI demo of SimpleListView, GroupedListView, and OutlineListView wrappers.
+// ABOUTME: Segmented picker switches between simple, grouped, and outline list demos.
 import Lists
 import SwiftUI
 import UIKit

--- a/Sources/ListKit/Algorithm/HeckelDiff.swift
+++ b/Sources/ListKit/Algorithm/HeckelDiff.swift
@@ -1,3 +1,6 @@
+// ABOUTME: O(n) Heckel diff algorithm for flat arrays.
+// ABOUTME: Produces inserts, deletes, and minimal moves via LIS-based reordering.
+
 // MARK: - HeckelDiff
 
 /// Implementation of Paul Heckel's 6-pass O(n) diff algorithm for flat arrays.

--- a/Sources/ListKit/Algorithm/SectionedDiff.swift
+++ b/Sources/ListKit/Algorithm/SectionedDiff.swift
@@ -1,3 +1,6 @@
+// ABOUTME: Per-section item diffing with cross-section move reconciliation.
+// ABOUTME: Combines HeckelDiff results into a StagedChangeset for batch updates.
+
 import Foundation
 
 enum SectionedDiff {

--- a/Sources/ListKit/Algorithm/StagedChangeset.swift
+++ b/Sources/ListKit/Algorithm/StagedChangeset.swift
@@ -1,3 +1,6 @@
+// ABOUTME: Groups diff results into a single value type for UICollectionView batch updates.
+// ABOUTME: Holds section/item deletes, inserts, moves, reloads, and reconfigures.
+
 import Foundation
 
 // MARK: - StagedChangeset

--- a/Sources/ListKit/DataSource/CollectionViewDiffableDataSource.swift
+++ b/Sources/ListKit/DataSource/CollectionViewDiffableDataSource.swift
@@ -1,3 +1,6 @@
+// ABOUTME: Drop-in replacement for UICollectionViewDiffableDataSource.
+// ABOUTME: Serializes concurrent applies via Task chaining and uses ListKit's own snapshots.
+
 import UIKit
 
 /// A data source that manages a `UICollectionView` using snapshots and animated batch updates.
@@ -229,13 +232,18 @@ public final class CollectionViewDiffableDataSource<
       fallbackRegistrations.count < 10,
       "Excessive supplementary element kinds (\(fallbackRegistrations.count)). Verify element kinds are not dynamically generated."
     )
-    if fallbackRegistrations[kind] == nil {
-      fallbackRegistrations[kind] = UICollectionView.SupplementaryRegistration<UICollectionReusableView>(
+    let registration: UICollectionView.SupplementaryRegistration<UICollectionReusableView>
+    if let existing = fallbackRegistrations[kind] {
+      registration = existing
+    } else {
+      let newReg = UICollectionView.SupplementaryRegistration<UICollectionReusableView>(
         elementKind: kind
       ) { _, _, _ in }
+      fallbackRegistrations[kind] = newReg
+      registration = newReg
     }
     return collectionView.dequeueConfiguredReusableSupplementary(
-      using: fallbackRegistrations[kind]!,
+      using: registration,
       for: indexPath
     )
   }

--- a/Sources/ListKit/Snapshot/DiffableDataSourceSectionSnapshot.swift
+++ b/Sources/ListKit/Snapshot/DiffableDataSourceSectionSnapshot.swift
@@ -1,3 +1,6 @@
+// ABOUTME: Hierarchical parent-child snapshot for outline-style lists within a section.
+// ABOUTME: Tracks expansion state and computes visible items via depth-first traversal.
+
 /// A hierarchical snapshot representing the items within a single section.
 ///
 /// Use a section snapshot to model parent–child relationships for outline-style lists.

--- a/Sources/ListKit/Snapshot/DiffableDataSourceSnapshot.swift
+++ b/Sources/ListKit/Snapshot/DiffableDataSourceSnapshot.swift
@@ -1,3 +1,6 @@
+// ABOUTME: Value-type snapshot of sections and items, replacing NSDiffableDataSourceSnapshot.
+// ABOUTME: Uses parallel arrays and lazy reverse indexes for O(1) lookups and O(n) diffing.
+
 // MARK: - DiffableDataSourceSnapshot
 
 /// A point-in-time representation of the data in a collection view, organized by sections and items.

--- a/Sources/Lists/Builder/DiffableDataSourceSnapshot+DSL.swift
+++ b/Sources/Lists/Builder/DiffableDataSourceSnapshot+DSL.swift
@@ -1,3 +1,5 @@
+// ABOUTME: DSL extensions on DiffableDataSourceSnapshot for single-type builders.
+// ABOUTME: Adds init(content:) using @SnapshotBuilder for declarative snapshots.
 import ListKit
 
 extension DiffableDataSourceSnapshot where ItemIdentifierType: CellViewModel {

--- a/Sources/Lists/Builder/DiffableDataSourceSnapshot+MixedDSL.swift
+++ b/Sources/Lists/Builder/DiffableDataSourceSnapshot+MixedDSL.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Mixed DSL extensions on DiffableDataSourceSnapshot for AnyItem snapshots.
+// ABOUTME: Adds init(content:) using @MixedSnapshotBuilder for heterogeneous cells.
 import ListKit
 
 extension DiffableDataSourceSnapshot where ItemIdentifierType == AnyItem {

--- a/Sources/Lists/Builder/ItemsBuilder.swift
+++ b/Sources/Lists/Builder/ItemsBuilder.swift
@@ -1,3 +1,5 @@
+// ABOUTME: @resultBuilder for constructing item arrays within a section.
+// ABOUTME: Supports if/else, for-in, and Optional for declarative item lists.
 /// A result builder for constructing arrays of a single ``CellViewModel`` type.
 ///
 /// Used by ``SimpleList/setItems(animatingDifferences:content:)`` and

--- a/Sources/Lists/Builder/MixedSnapshotBuilder.swift
+++ b/Sources/Lists/Builder/MixedSnapshotBuilder.swift
@@ -1,3 +1,5 @@
+// ABOUTME: @resultBuilder types for mixed-type snapshots with heterogeneous cells.
+// ABOUTME: Defines MixedSection, MixedItemsBuilder, and MixedSnapshotBuilder.
 // MARK: - MixedSection
 
 /// A section containing mixed `CellViewModel` types, wrapped as ``AnyItem``.

--- a/Sources/Lists/Builder/OutlineItemBuilder.swift
+++ b/Sources/Lists/Builder/OutlineItemBuilder.swift
@@ -1,3 +1,5 @@
+// ABOUTME: @resultBuilder for hierarchical OutlineItem trees.
+// ABOUTME: Also extends OutlineItem with a builder-based children initializer.
 // MARK: - OutlineItemBuilder
 
 /// A result builder for constructing arrays of ``OutlineItem`` declaratively.

--- a/Sources/Lists/Builder/SnapshotBuilder.swift
+++ b/Sources/Lists/Builder/SnapshotBuilder.swift
@@ -1,3 +1,5 @@
+// ABOUTME: @resultBuilder for single-type snapshots with SnapshotSection.
+// ABOUTME: Defines SnapshotSection (section + items) and SnapshotBuilder.
 // MARK: - SnapshotSection
 
 /// A section definition used by the ``SnapshotBuilder`` result builder DSL.

--- a/Sources/Lists/Configurations/GroupedList.swift
+++ b/Sources/Lists/Configurations/GroupedList.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Multi-section grouped list configuration with headers and footers.
+// ABOUTME: Manages UICollectionView layout, data source, and delegate internally.
 import ListKit
 import UIKit
 

--- a/Sources/Lists/Configurations/ListConfigurationBridge.swift
+++ b/Sources/Lists/Configurations/ListConfigurationBridge.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Shared bridge resolving IndexPath-to-Item for layout config handlers.
+// ABOUTME: Centralizes delegate logic (swipe, separator, selection) across list types.
 @preconcurrency import UIKit
 
 /// A reference-type bridge that resolves `IndexPath` -> `Item` for layout configuration handlers

--- a/Sources/Lists/Configurations/OutlineList.swift
+++ b/Sources/Lists/Configurations/OutlineList.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Hierarchical outline list with expand/collapse via section snapshots.
+// ABOUTME: Defines OutlineItem (tree node) and OutlineList (UICollectionView config).
 import ListKit
 import UIKit
 

--- a/Sources/Lists/Configurations/SimpleList.swift
+++ b/Sources/Lists/Configurations/SimpleList.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Single-section flat list configuration backed by UICollectionView.
+// ABOUTME: Simplest list type -- just provide items and handlers.
 import ListKit
 import UIKit
 

--- a/Sources/Lists/DataSource/ListDataSource.swift
+++ b/Sources/Lists/DataSource/ListDataSource.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Type-safe data source for a single CellViewModel type.
+// ABOUTME: Wraps CollectionViewDiffableDataSource with automatic cell registration.
 import ListKit
 import UIKit
 

--- a/Sources/Lists/DataSource/MixedListDataSource.swift
+++ b/Sources/Lists/DataSource/MixedListDataSource.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Heterogeneous data source supporting multiple CellViewModel types.
+// ABOUTME: Uses AnyItem type erasure with lazy cell registration via DynamicCellRegistrar.
 import ListKit
 import UIKit
 

--- a/Sources/Lists/Extensions/CellViewModel+Identifiable.swift
+++ b/Sources/Lists/Extensions/CellViewModel+Identifiable.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Default Hashable/Equatable for CellViewModel & Identifiable types.
+// ABOUTME: Derives equality and hashing from id only; content changes need reconfigure.
 import Foundation
 
 /// Automatic id-based `Hashable`/`Equatable` for `CellViewModel & Identifiable`.

--- a/Sources/Lists/Extensions/LayoutHelpers.swift
+++ b/Sources/Lists/Extensions/LayoutHelpers.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Factory methods for UICollectionViewCompositionalLayout list configs.
+// ABOUTME: Provides plain, grouped, insetGrouped, sidebar, and sidebarPlain layouts.
 import UIKit
 
 /// Factory methods for common `UICollectionViewCompositionalLayout` list configurations.

--- a/Sources/Lists/Extensions/RefreshControlConfiguration.swift
+++ b/Sources/Lists/Extensions/RefreshControlConfiguration.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Pull-to-refresh support for UIKit list configurations.
+// ABOUTME: RefreshControlManager owns the async refresh lifecycle and spinner dismissal.
 import UIKit
 
 /// Configures a `UIRefreshControl` on a collection view when `onRefresh` is non-nil,

--- a/Sources/Lists/Extensions/UICollectionViewListCell+ListContent.swift
+++ b/Sources/Lists/Extensions/UICollectionViewListCell+ListContent.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Convenience methods on UICollectionViewListCell for content configuration.
+// ABOUTME: Provides setListContent helpers to reduce boilerplate cell setup code.
 import UIKit
 
 extension UICollectionViewListCell {

--- a/Sources/Lists/Mixed/AnyItem.swift
+++ b/Sources/Lists/Mixed/AnyItem.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Type-erased CellViewModel wrapper enabling heterogeneous cell types.
+// ABOUTME: Also defines DynamicCellRegistrar for lazy cell class registration.
 import UIKit
 
 // MARK: - AnyItem

--- a/Sources/Lists/Protocols/CellViewModel.swift
+++ b/Sources/Lists/Protocols/CellViewModel.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Core CellViewModel protocol: Hashable + Sendable + cell configuration.
+// ABOUTME: Also defines CellRegistrar for automatic UICollectionView.CellRegistration.
 import UIKit
 
 // MARK: - CellViewModel

--- a/Sources/Lists/Protocols/ContentEquatable.swift
+++ b/Sources/Lists/Protocols/ContentEquatable.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Opt-in protocol for automatic content change detection in data sources.
+// ABOUTME: Enables auto-reconfigure when identity matches but content differs.
 // MARK: - ContentEquatable
 
 /// Opt-in protocol for automatic content change detection in diffable data sources.

--- a/Sources/Lists/Protocols/ListCellViewModel.swift
+++ b/Sources/Lists/Protocols/ListCellViewModel.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Convenience protocol defaulting Cell to UICollectionViewListCell.
+// ABOUTME: Eliminates the typealias boilerplate for the most common cell type.
 import UIKit
 
 /// A convenience refinement of ``CellViewModel`` that defaults the cell type to `UICollectionViewListCell`.

--- a/Sources/Lists/Protocols/SectionModel.swift
+++ b/Sources/Lists/Protocols/SectionModel.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Section struct bundling an ID, items array, and optional header/footer text.
+// ABOUTME: Used by GroupedList and ListDataSource for multi-section list definitions.
 // MARK: - SectionModel
 
 /// A section with an identifier, items, and optional header/footer text.

--- a/Sources/Lists/SwiftUI/GroupedListView+Modifiers.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView+Modifiers.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI-style chained modifiers for GroupedListView configuration.
+// ABOUTME: Includes onMove, headerContentProvider, and footerContentProvider.
 import UIKit
 
 /// SwiftUI-style modifier API for ``GroupedListView``.

--- a/Sources/Lists/SwiftUI/GroupedListView.swift
+++ b/Sources/Lists/SwiftUI/GroupedListView.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI wrapper (UIViewRepresentable) around GroupedList.
+// ABOUTME: Supports sections, headers/footers, inline content, and chained modifiers.
 import SwiftUI
 import UIKit
 

--- a/Sources/Lists/SwiftUI/InlineCellViewModel.swift
+++ b/Sources/Lists/SwiftUI/InlineCellViewModel.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Type-erased CellViewModel wrapping a data value and @ViewBuilder closure.
+// ABOUTME: Used by inline-content convenience inits on SwiftUI list wrappers.
 import SwiftUI
 import UIKit
 

--- a/Sources/Lists/SwiftUI/ListAccessory.swift
+++ b/Sources/Lists/SwiftUI/ListAccessory.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Pure-Swift enum mapping to UICellAccessory for use in cell view models.
+// ABOUTME: Includes standard, custom, toggle, badge, and other accessory types.
 import UIKit
 
 /// A pure-Swift cell accessory type that replaces `UICellAccessory` in SwiftUI cell view models.

--- a/Sources/Lists/SwiftUI/OutlineListView+Modifiers.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView+Modifiers.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI-style chained modifiers for OutlineListView configuration.
+// ABOUTME: Provides onSelect, onDelete, onRefresh, swipe actions, and contextMenu.
 import UIKit
 
 /// SwiftUI-style modifier API for ``OutlineListView``.

--- a/Sources/Lists/SwiftUI/OutlineListView.swift
+++ b/Sources/Lists/SwiftUI/OutlineListView.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI wrapper (UIViewRepresentable) around OutlineList.
+// ABOUTME: Supports hierarchical items, inline content, and chained modifiers.
 import SwiftUI
 import UIKit
 

--- a/Sources/Lists/SwiftUI/SimpleListView+Modifiers.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView+Modifiers.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI-style chained modifiers for SimpleListView configuration.
+// ABOUTME: Provides onSelect, onDelete, onMove, onRefresh, separatorHandler, and more.
 import UIKit
 
 /// SwiftUI-style modifier API for ``SimpleListView``.

--- a/Sources/Lists/SwiftUI/SimpleListView.swift
+++ b/Sources/Lists/SwiftUI/SimpleListView.swift
@@ -1,3 +1,5 @@
+// ABOUTME: SwiftUI wrapper (UIViewRepresentable) around SimpleList.
+// ABOUTME: Supports flat item lists, inline content, and chained modifiers.
 import SwiftUI
 import UIKit
 

--- a/Sources/Lists/SwiftUI/SwiftUICellViewModel.swift
+++ b/Sources/Lists/SwiftUI/SwiftUICellViewModel.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Protocol extending CellViewModel with a SwiftUI body and accessories.
+// ABOUTME: Default configure(_:) renders body via UIHostingConfiguration.
 import SwiftUI
 import UIKit
 

--- a/Tests/Benchmarks/AnyItemBenchmarks.swift
+++ b/Tests/Benchmarks/AnyItemBenchmarks.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Benchmarks measuring AnyItem type erasure overhead vs concrete ListDataSource.
+// ABOUTME: Compares wrapping, snapshot building, diffing, and DSL paths for mixed types.
 import Foundation
 import Lists
 import Testing

--- a/Tests/Benchmarks/AppleComparisonBenchmarks.swift
+++ b/Tests/Benchmarks/AppleComparisonBenchmarks.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Head-to-head benchmarks comparing ListKit vs Apple's NSDiffableDataSourceSnapshot.
+// ABOUTME: Tests build, query, delete, and reload operations with strict timing assertions.
 import Foundation
 import ListKit
 import Testing

--- a/Tests/Benchmarks/BenchmarkHelpers.swift
+++ b/Tests/Benchmarks/BenchmarkHelpers.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Shared benchmark utilities: median-of-N timing, millisecond formatting, speedup ratios.
+// ABOUTME: Provides benchmark(), ms(), and speedup() helpers used by all benchmark test files.
 import Foundation
 
 /// Measures the median duration over `runs` iterations after `warmup` throwaway runs.

--- a/Tests/Benchmarks/BenchmarkReport.swift
+++ b/Tests/Benchmarks/BenchmarkReport.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Generates a markdown benchmark report comparing ListKit vs Apple snapshot operations.
+// ABOUTME: Writes results to /tmp/listkit_benchmark_results.txt.
 import Foundation
 import ListKit
 import Testing

--- a/Tests/Benchmarks/IGListDiffBenchmarks.swift
+++ b/Tests/Benchmarks/IGListDiffBenchmarks.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Benchmarks comparing ListKit's Heckel diff vs IGListKit's Obj-C++ ListDiff.
+// ABOUTME: Tests 10k/50k elements, no-change, and shuffle scenarios.
 import Foundation
 import IGListDiffKit
 import Testing

--- a/Tests/Benchmarks/ReactiveCollectionsKitBenchmarks.swift
+++ b/Tests/Benchmarks/ReactiveCollectionsKitBenchmarks.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Benchmarks comparing ListKit snapshot construction vs ReactiveCollectionsKit.
+// ABOUTME: Measures model build overhead and type erasure cost across various data sizes.
 import Foundation
 import ListKit
 import ReactiveCollectionsKit

--- a/Tests/ListKitTests/BatchUpdateSafetyTests.swift
+++ b/Tests/ListKitTests/BatchUpdateSafetyTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests that SectionedDiff produces changesets safe for UICollectionView batch updates.
+// ABOUTME: Validates index ordering, deduplication, and section/item operation consistency.
 import Foundation
 import Testing
 @testable import ListKit

--- a/Tests/ListKitTests/CollectionViewDiffableDataSourceTests.swift
+++ b/Tests/ListKitTests/CollectionViewDiffableDataSourceTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for CollectionViewDiffableDataSource: apply, query, move, and supplementary views.
+// ABOUTME: Covers init, snapshot apply, section/item queries, move handling, and reloadData.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListKitTests/DataSourceLifecycleTests.swift
+++ b/Tests/ListKitTests/DataSourceLifecycleTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for data source lifecycle: serialization, cancellation, and deallocation safety.
+// ABOUTME: Validates rapid apply calls, empty snapshots, and reloadData interleaving.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListKitTests/HeckelDiffEdgeCaseTests.swift
+++ b/Tests/ListKitTests/HeckelDiffEdgeCaseTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Edge case tests for HeckelDiff: duplicates, cascading moves, index coverage.
+// ABOUTME: Inspired by IGListKit's test suite and Heckel's 1978 paper examples.
 import Testing
 @testable import ListKit
 

--- a/Tests/ListKitTests/HeckelDiffTests.swift
+++ b/Tests/ListKitTests/HeckelDiffTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Core unit tests for the O(n) HeckelDiff algorithm.
+// ABOUTME: Covers inserts, deletes, moves, duplicates, LIS-based move minimization.
 import Testing
 @testable import ListKit
 

--- a/Tests/ListKitTests/PerformanceTests.swift
+++ b/Tests/ListKitTests/PerformanceTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Performance tests verifying O(n) scaling for HeckelDiff and SectionedDiff.
+// ABOUTME: Tests up to 100k elements with timing assertions to catch regressions.
 import Foundation
 import Testing
 @testable import ListKit

--- a/Tests/ListKitTests/SectionSnapshotTests.swift
+++ b/Tests/ListKitTests/SectionSnapshotTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for DiffableDataSourceSectionSnapshot: hierarchical tree operations.
+// ABOUTME: Covers append, expand/collapse, visibility, sub-snapshots, and deletion cascades.
 import Testing
 @testable import ListKit
 

--- a/Tests/ListKitTests/SectionedDiffTests.swift
+++ b/Tests/ListKitTests/SectionedDiffTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for SectionedDiff: section and item inserts, deletes, moves, and reloads.
+// ABOUTME: Validates cross-section moves, reload markers, and changeset properties.
 import Foundation
 import Testing
 @testable import ListKit

--- a/Tests/ListKitTests/SnapshotTests.swift
+++ b/Tests/ListKitTests/SnapshotTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for DiffableDataSourceSnapshot: sections, items, mutations, and equality.
+// ABOUTME: Covers append, insert, delete, move, reload, replace, and convenience initializers.
 import Testing
 @testable import ListKit
 

--- a/Tests/ListsTests/CellViewModelTests.swift
+++ b/Tests/ListsTests/CellViewModelTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for the CellViewModel protocol: Hashable, Sendable, and cell configuration.
+// ABOUTME: Also tests CellRegistrar dequeue behavior with UICollectionView.
 import Testing
 import UIKit
 @testable import Lists

--- a/Tests/ListsTests/ContentEquatableTests.swift
+++ b/Tests/ListsTests/ContentEquatableTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for ContentEquatable protocol and auto-reconfigure behavior on data sources.
+// ABOUTME: Validates type-erased content equality and AnyItem content change detection.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/DSLEquivalenceTests.swift
+++ b/Tests/ListsTests/DSLEquivalenceTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests verifying SnapshotBuilder DSL produces identical snapshots to manual construction.
+// ABOUTME: Covers conditionals, loops, Identifiable view models, and diff equivalence.
 import Foundation
 import Testing
 @testable import ListKit

--- a/Tests/ListsTests/GroupedListTests.swift
+++ b/Tests/ListsTests/GroupedListTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for GroupedList: sections with headers/footers, SectionModel, and callbacks.
+// ABOUTME: Covers setSections, selection, deletion, move handlers, and query APIs.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/Helpers/TestViewModels.swift
+++ b/Tests/ListsTests/Helpers/TestViewModels.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Shared test fixtures: TextItem (UUID-based) and NumberItem (value-based) CellViewModels.
+// ABOUTME: Used across ListsTests for snapshot, DSL, and configuration testing.
 import UIKit
 @testable import Lists
 

--- a/Tests/ListsTests/ListAccessoryTests.swift
+++ b/Tests/ListsTests/ListAccessoryTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for ListAccessory enum: equality, hashing, and UICellAccessory production.
+// ABOUTME: Covers all cases: label, badge, toggle, image, progress, popUpMenu, and more.
 import Testing
 import UIKit
 @testable import Lists

--- a/Tests/ListsTests/ListCellViewModelTests.swift
+++ b/Tests/ListsTests/ListCellViewModelTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for ListCellViewModel protocol and setListContent cell configuration helpers.
+// ABOUTME: Also tests SwiftUI view modifiers for SimpleListView, GroupedListView, OutlineListView.
 import Testing
 import UIKit
 @testable import Lists

--- a/Tests/ListsTests/ListConfigurationTests.swift
+++ b/Tests/ListsTests/ListConfigurationTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for list configuration: appearance, separators, headers, footers, and selection.
+// ABOUTME: Covers SimpleList, GroupedList, OutlineList, ListLayout, and ListConfigurationBridge.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/MixedListTests.swift
+++ b/Tests/ListsTests/MixedListTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for MixedListDataSource, AnyItem, MixedItemsBuilder, and MixedSection DSL.
+// ABOUTME: Covers type erasure equality/hashing, mixed-type snapshots, and builder control flow.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/OutlineItemBuilderTests.swift
+++ b/Tests/ListsTests/OutlineItemBuilderTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for OutlineItemBuilder result builder: leaf nodes, nesting, and control flow.
+// ABOUTME: Also tests OutlineList.setItems with the builder DSL.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/OutlineListTests.swift
+++ b/Tests/ListsTests/OutlineListTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for OutlineList: hierarchical items, expand/collapse, and selection.
+// ABOUTME: Covers flat items, nested expansion, programmatic toggle, and cancellation safety.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/PerformanceTests.swift
+++ b/Tests/ListsTests/PerformanceTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Performance tests for the Lists module: DSL build, full pipeline diff, pagination.
+// ABOUTME: Validates DSL overhead vs manual build and simulates incremental scroll updates.
 import Foundation
 import Testing
 @testable import ListKit

--- a/Tests/ListsTests/SimpleListTests.swift
+++ b/Tests/ListsTests/SimpleListTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for SimpleList: setItems, selection, deselection, move, delete, and builder DSL.
+// ABOUTME: Covers single/multiple selection, programmatic select/deselect, and cancellation.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tests/ListsTests/SnapshotBuilderTests.swift
+++ b/Tests/ListsTests/SnapshotBuilderTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Tests for SnapshotBuilder DSL: sections, items, conditionals, loops, and headers.
+// ABOUTME: Also tests SectionModel builder init, snapshot contains helpers, and availability.
 import Testing
 import UIKit
 @testable import ListKit

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -1,6 +1,9 @@
+// ABOUTME: Tuist global configuration for the ListKit project.
+// ABOUTME: Sets Xcode compatibility and Swift 6.0 language version.
+
 import ProjectDescription
 
 let config = Config(
-    compatibleXcodeVersions: .all,
-    swiftVersion: "6.0"
+  compatibleXcodeVersions: .all,
+  swiftVersion: "6.0"
 )

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -1,9 +1,12 @@
+// ABOUTME: Tuist workspace manifest defining the ListKit workspace structure.
+// ABOUTME: Includes the main package and the Example app as workspace projects.
+
 import ProjectDescription
 
 let workspace = Workspace(
-    name: "ListKit",
-    projects: [
-        ".",
-        "Example",
-    ]
+  name: "ListKit",
+  projects: [
+    ".",
+    "Example",
+  ]
 )


### PR DESCRIPTION
## Summary

- Adds `// ABOUTME:` file-level summary comments to all 83 Swift files across `Sources/`, `Tests/`, `Example/`, and root config files
- Codifies the `// ABOUTME:` convention in `AGENTS.md` under Code Style, requiring all `.swift` files to begin with a 1-2 line summary before imports
- Each comment describes what the file defines/provides and optionally notes key relationships or constraints

## Motivation

File-level orientation comments let developers and agents instantly understand a file's purpose without reading the full source. The `// ABOUTME:` prefix is grep-friendly, making it trivial to build a codebase map:

```bash
grep -r "// ABOUTME:" Sources/ --include="*.swift"
```

## Test plan

- [x] All 83 project-owned Swift files have `// ABOUTME:` comments at line 1
- [x] Comments are placed before `import` statements
- [x] Each line stays under 100 characters
- [x] SwiftFormat lint passes (`make lint` via pre-commit hook)
- [ ] Verify `make build` still succeeds (comment-only change, no code impact)