### PR TITLE
Add struct-based Apple comparison benchmarks with ID-only hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ All benchmarks run in **Release configuration** with median-of-15 and 5 warmup i
 | Reload 5k items | 0.099 ms | 1.547 ms | **15.7x** |
 | Query itemIdentifiers 100x | 0.051 ms | 46.364 ms | **908.3x** |
 
+#### With struct items (ID-only hashing)
+
+Real-world items typically hash by ID only, not all fields. These benchmarks use a struct with `hash(into:)` and `==` that only consider the `id` property — the pattern used by most apps.
+
+| Operation | ListKit | Apple | Speedup |
+|:---|---:|---:|---:|
+| Build 10k struct items | 0.003 ms | 2.775 ms | **900.2x** |
+| Delete 5k struct items | 1.426 ms | 4.957 ms | **3.5x** |
+| Reload 5k struct items | 0.213 ms | 3.685 ms | **17.3x** |
+
 ListKit snapshots are pure Swift value types with flat array storage and a lazy reverse index. Apple's `NSDiffableDataSourceSnapshot` is backed by Objective-C runtime overhead and per-query hashing.
 
 ### vs IGListKit (Instagram)

--- a/Tests/Benchmarks/BenchmarkReport.swift
+++ b/Tests/Benchmarks/BenchmarkReport.swift
@@ -135,6 +135,59 @@ struct BenchmarkReport {
     } }
     log("| Query itemIdentifiers 100x | \(ms(lkQ)) ms | \(ms(apQ)) ms | **\(speedup(lkQ, apQ))** |")
 
+    // Struct-based benchmarks (ID-only hashing)
+    log("")
+    log("#### With struct items (ID-only hashing)")
+    log("")
+    log("| Operation | ListKit | Apple | Speedup |")
+    log("|:---|---:|---:|---:|")
+
+    // Build 10k struct items
+    let structItems10k = (0 ..< 10000).map { BenchItem(id: $0, value: $0 * 7) }
+    let lkStruct10k = benchmark {
+      var s = DiffableDataSourceSnapshot<String, BenchItem>()
+      s.appendSections(["main"])
+      s.appendItems(structItems10k, toSection: "main")
+    }
+    let apStruct10k = benchmark {
+      var s = NSDiffableDataSourceSnapshot<String, BenchItem>()
+      s.appendSections(["main"])
+      s.appendItems(structItems10k, toSection: "main")
+    }
+    log("| Build 10k struct items | \(ms(lkStruct10k)) ms | \(ms(apStruct10k)) ms | **\(speedup(lkStruct10k, apStruct10k))** |")
+
+    // Delete 5k struct items from 10k
+    let structDelTarget = (0 ..< 5000).map { BenchItem(id: $0, value: $0 * 7) }
+    let lkStructDel = benchmark {
+      var s = DiffableDataSourceSnapshot<String, BenchItem>()
+      s.appendSections(["main"])
+      s.appendItems(structItems10k, toSection: "main")
+      s.deleteItems(structDelTarget)
+    }
+    let apStructDel = benchmark {
+      var s = NSDiffableDataSourceSnapshot<String, BenchItem>()
+      s.appendSections(["main"])
+      s.appendItems(structItems10k, toSection: "main")
+      s.deleteItems(structDelTarget)
+    }
+    log("| Delete 5k struct items | \(ms(lkStructDel)) ms | \(ms(apStructDel)) ms | **\(speedup(lkStructDel, apStructDel))** |")
+
+    // Reload 5k struct items
+    let structRlTarget = (0 ..< 5000).map { BenchItem(id: $0, value: $0 * 7) }
+    let lkStructRl = benchmark {
+      var s = DiffableDataSourceSnapshot<String, BenchItem>()
+      s.appendSections(["main"])
+      s.appendItems(structItems10k, toSection: "main")
+      s.reloadItems(structRlTarget)
+    }
+    let apStructRl = benchmark {
+      var s = NSDiffableDataSourceSnapshot<String, BenchItem>()
+      s.appendSections(["main"])
+      s.appendItems(structItems10k, toSection: "main")
+      s.reloadItems(structRlTarget)
+    }
+    log("| Reload 5k struct items | \(ms(lkStructRl)) ms | \(ms(apStructRl)) ms | **\(speedup(lkStructRl, apStructRl))** |")
+
     let output = lines.joined(separator: "\n")
     let path = "/tmp/listkit_benchmark_results.txt"
     try output.write(toFile: path, atomically: true, encoding: .utf8)


### PR DESCRIPTION
## Summary

- Adds `BenchItem` struct type that hashes/equates by `id` only (ignoring content fields) — the realistic pattern used by most apps
- Adds 4 new struct-based Apple comparison benchmarks: build, delete, reload, and diff
- Adds struct benchmarks to the report generator so `make benchmark` outputs numbers for the README
- Updates README with new "With struct items (ID-only hashing)" subsection

Previously all Apple comparison benchmarks used bare `Int` as the item type, where `hash == value == identity`. Real-world items typically have stable identifiers and mutable content, with `hash(into:)` and `==` only considering the `id` property.

## Test plan

- [x] `make benchmark` passes — all 29 benchmarks green including 4 new struct-based tests
- [x] `make format` clean
- [x] README numbers match report output