### PR TITLE
Add realistic UUID-based Apple comparison benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Realistic UUID-based benchmarks comparing ListKit vs Apple using the `Item.ID` pattern with `Identifiable` model types
+
+### Fixed
+
+- `speedup()` benchmark helper now correctly handles durations >= 1 second (previously ignored the `seconds` component)
+
 ## [0.6.0] - 2026-02-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ All benchmarks run in **Release configuration** with median-of-15 and 5 warmup i
 | Reload 5k items | 0.099 ms | 1.547 ms | **15.7x** |
 | Query itemIdentifiers 100x | 0.051 ms | 46.364 ms | **908.3x** |
 
-#### With struct items (ID-only hashing)
+#### With Item.ID (UUID) — realistic pattern
 
-Real-world items typically hash by ID only, not all fields. These benchmarks use a struct with `hash(into:)` and `==` that only consider the `id` property — the pattern used by most apps.
+Real-world apps store `Item.ID` in the snapshot, not the full model — the [Apple-recommended pattern](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource). These benchmarks use `UUID` identifiers from an `Identifiable` model type.
 
 | Operation | ListKit | Apple | Speedup |
 |:---|---:|---:|---:|
-| Build 10k struct items | 0.003 ms | 2.775 ms | **900.2x** |
-| Delete 5k struct items | 1.426 ms | 4.957 ms | **3.5x** |
-| Reload 5k struct items | 0.213 ms | 3.685 ms | **17.3x** |
+| Build 10k Item.IDs | 0.003 ms | 2.269 ms | **789.2x** |
+| Delete 5k Item.IDs | 1.358 ms | 4.084 ms | **3.0x** |
+| Reload 5k Item.IDs | 0.284 ms | 2.738 ms | **9.6x** |
 
 ListKit snapshots are pure Swift value types with flat array storage and a lazy reverse index. Apple's `NSDiffableDataSourceSnapshot` is backed by Objective-C runtime overhead and per-query hashing.
 

--- a/Tests/Benchmarks/BenchmarkReport.swift
+++ b/Tests/Benchmarks/BenchmarkReport.swift
@@ -135,58 +135,59 @@ struct BenchmarkReport {
     } }
     log("| Query itemIdentifiers 100x | \(ms(lkQ)) ms | \(ms(apQ)) ms | **\(speedup(lkQ, apQ))** |")
 
-    // Struct-based benchmarks (ID-only hashing)
+    // Realistic benchmarks (Item.ID as snapshot identifier)
     log("")
-    log("#### With struct items (ID-only hashing)")
+    log("#### With Item.ID (UUID) — realistic pattern")
     log("")
     log("| Operation | ListKit | Apple | Speedup |")
     log("|:---|---:|---:|---:|")
 
-    // Build 10k struct items
-    let structItems10k = (0 ..< 10000).map { BenchItem(id: $0, value: $0 * 7) }
-    let lkStruct10k = benchmark {
-      var s = DiffableDataSourceSnapshot<String, BenchItem>()
-      s.appendSections(["main"])
-      s.appendItems(structItems10k, toSection: "main")
-    }
-    let apStruct10k = benchmark {
-      var s = NSDiffableDataSourceSnapshot<String, BenchItem>()
-      s.appendSections(["main"])
-      s.appendItems(structItems10k, toSection: "main")
-    }
-    log("| Build 10k struct items | \(ms(lkStruct10k)) ms | \(ms(apStruct10k)) ms | **\(speedup(lkStruct10k, apStruct10k))** |")
+    let ids10k = makeBenchItemIDs(10000)
 
-    // Delete 5k struct items from 10k
-    let structDelTarget = (0 ..< 5000).map { BenchItem(id: $0, value: $0 * 7) }
-    let lkStructDel = benchmark {
-      var s = DiffableDataSourceSnapshot<String, BenchItem>()
+    // Build 10k Item.IDs
+    let lkUUID10k = benchmark {
+      var s = DiffableDataSourceSnapshot<String, BenchItem.ID>()
       s.appendSections(["main"])
-      s.appendItems(structItems10k, toSection: "main")
-      s.deleteItems(structDelTarget)
+      s.appendItems(ids10k, toSection: "main")
     }
-    let apStructDel = benchmark {
-      var s = NSDiffableDataSourceSnapshot<String, BenchItem>()
+    let apUUID10k = benchmark {
+      var s = NSDiffableDataSourceSnapshot<String, BenchItem.ID>()
       s.appendSections(["main"])
-      s.appendItems(structItems10k, toSection: "main")
-      s.deleteItems(structDelTarget)
+      s.appendItems(ids10k, toSection: "main")
     }
-    log("| Delete 5k struct items | \(ms(lkStructDel)) ms | \(ms(apStructDel)) ms | **\(speedup(lkStructDel, apStructDel))** |")
+    log("| Build 10k Item.IDs | \(ms(lkUUID10k)) ms | \(ms(apUUID10k)) ms | **\(speedup(lkUUID10k, apUUID10k))** |")
 
-    // Reload 5k struct items
-    let structRlTarget = (0 ..< 5000).map { BenchItem(id: $0, value: $0 * 7) }
-    let lkStructRl = benchmark {
-      var s = DiffableDataSourceSnapshot<String, BenchItem>()
+    // Delete 5k Item.IDs from 10k
+    let idsDelTarget = Array(ids10k.prefix(5000))
+    let lkUUIDDel = benchmark {
+      var s = DiffableDataSourceSnapshot<String, BenchItem.ID>()
       s.appendSections(["main"])
-      s.appendItems(structItems10k, toSection: "main")
-      s.reloadItems(structRlTarget)
+      s.appendItems(ids10k, toSection: "main")
+      s.deleteItems(idsDelTarget)
     }
-    let apStructRl = benchmark {
-      var s = NSDiffableDataSourceSnapshot<String, BenchItem>()
+    let apUUIDDel = benchmark {
+      var s = NSDiffableDataSourceSnapshot<String, BenchItem.ID>()
       s.appendSections(["main"])
-      s.appendItems(structItems10k, toSection: "main")
-      s.reloadItems(structRlTarget)
+      s.appendItems(ids10k, toSection: "main")
+      s.deleteItems(idsDelTarget)
     }
-    log("| Reload 5k struct items | \(ms(lkStructRl)) ms | \(ms(apStructRl)) ms | **\(speedup(lkStructRl, apStructRl))** |")
+    log("| Delete 5k Item.IDs | \(ms(lkUUIDDel)) ms | \(ms(apUUIDDel)) ms | **\(speedup(lkUUIDDel, apUUIDDel))** |")
+
+    // Reload 5k Item.IDs
+    let idsRlTarget = Array(ids10k.prefix(5000))
+    let lkUUIDRl = benchmark {
+      var s = DiffableDataSourceSnapshot<String, BenchItem.ID>()
+      s.appendSections(["main"])
+      s.appendItems(ids10k, toSection: "main")
+      s.reloadItems(idsRlTarget)
+    }
+    let apUUIDRl = benchmark {
+      var s = NSDiffableDataSourceSnapshot<String, BenchItem.ID>()
+      s.appendSections(["main"])
+      s.appendItems(ids10k, toSection: "main")
+      s.reloadItems(idsRlTarget)
+    }
+    log("| Reload 5k Item.IDs | \(ms(lkUUIDRl)) ms | \(ms(apUUIDRl)) ms | **\(speedup(lkUUIDRl, apUUIDRl))** |")
 
     let output = lines.joined(separator: "\n")
     let path = "/tmp/listkit_benchmark_results.txt"


### PR DESCRIPTION
## Summary

- Adds `BenchItem` (`Identifiable` with `UUID` id) and `makeBenchItemIDs` helper to shared `BenchmarkHelpers.swift`
- Adds 4 realistic benchmarks using `Item.ID` (UUID) as snapshot identifier — the Apple-recommended pattern
- Fixes `speedup()` helper which was ignoring the `seconds` component of `Duration` (would produce wrong results for benchmarks >= 1s)
- Renames misleading `us` variable to `milliseconds` in `ms()` helper
- Updates README and CHANGELOG with new benchmark numbers

Addresses review findings from deep code review (code reviewer, silent failure hunter, pattern scout, iOS platform reviewer).

## Test plan

- [x] `make benchmark` passes — all 29 benchmarks green
- [x] `make format` clean
- [x] README numbers match report output
- [x] CHANGELOG entry added under `[Unreleased]`