### PR TITLE
Offload diff computation to background thread for large datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `CollectionViewDiffableDataSource.performApply()` now offloads diff computation to a background thread for snapshots with ≥1,000 items, keeping the main thread free during large dataset updates
+
 ### Added
 
 - Realistic UUID-based benchmarks comparing ListKit vs Apple using the `Item.ID` pattern with `Identifiable` model types


### PR DESCRIPTION
## Summary

- `CollectionViewDiffableDataSource.performApply()` now offloads `SectionedDiff.diff()` to a `Task.detached(priority: .userInitiated)` when the snapshot contains ≥1,000 items, keeping the main thread free during large dataset updates
- Small datasets (<1,000 items) still diff inline to avoid thread-hop overhead
- Post-diff cancellation guard restores the old snapshot to prevent snapshot/UI desync

## Test plan

- [x] 3 new tests: `backgroundDiffProducesCorrectState`, `cancelledLargeApplyDoesNotCorruptState`, `rapidLargeAppliesSerializeCorrectly`
- [x] All 180 existing tests pass (`make test-listkit`)
- [x] Benchmarks show no regression (`make benchmark`)
- [x] Deep review passed (6 agents: code, errors, concurrency, iOS, performance, tests)
- [x] Format + lint clean