### PR TITLE
Stamp changelog for 0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-02-18
+
 ### Changed
 
 - `CollectionViewDiffableDataSource.performApply()` now offloads diff computation to a background thread for snapshots with ≥1,000 items, keeping the main thread free during large dataset updates


### PR DESCRIPTION
## Summary

- Stamps the changelog for the 0.6.1 release

## Test plan

- [x] No code changes — changelog only