### PR TITLE
fix batch-update datasource-state mismatch in CollectionViewDiffableDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `CollectionViewDiffableDataSource.performApply()` to keep data source counts in the pre-update state until animated batch updates begin, preventing `UICollectionView` "Invalid batch updates detected..." and "attempt to delete item ... before the update" crashes caused by before/after state mismatch.
+
 ## [0.6.1] - 2026-02-18
 
 ### Changed


### PR DESCRIPTION
## Root cause
`CollectionViewDiffableDataSource.performApply` updated `currentSnapshot` to the new snapshot before animated structural `performBatchUpdates` executed. Because `currentSnapshot` is the backing state for `UICollectionViewDataSource` counts, UIKit could observe after-state counts while validating before-state deletes/inserts, producing crashes such as:
- `Invalid batch updates detected...`
- `attempt to delete item ... before the update`

## Fix details
- Kept `currentSnapshot` on the old snapshot until the animated batch transaction begins.
- Moved the `currentSnapshot = snapshot` transition into the `performBatchUpdates` update block so UIKit sees a consistent before/after model transition.
- Preserved the deallocated collection-view path by still updating `currentSnapshot` immediately when `collectionView` is nil.
- Kept apply serialization/cancellation behavior intact.
- Added regression tests for animated structural updates:
  - insert scenario verifies old count before and new count after batch updates
  - delete scenario verifies old count before and new count after batch updates

## Why this is safe
- Public API is unchanged.
- Diffing and operation ordering remain unchanged; only snapshot state transition timing was adjusted.
- Non-animated and non-structural paths still update `currentSnapshot` to the latest snapshot in-place.
- Regression tests directly lock the invariant that caused the crash pattern.

## Test plan/results
- `make generate`
- `make test-listkit`
- Result: pass (`182 tests`), including new regressions:
  - `animatedApplyInsertUsesOldThenNewDataSourceCounts`
  - `animatedApplyDeleteUsesOldThenNewDataSourceCounts`

## Risk/rollback notes
- Risk is limited to `performApply` snapshot timing around animated structural batches.
- If any downstream issue appears, rollback can be done by reverting commit `8f8c43d1`.