### PR TITLE
Add comprehensive animated apply test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Comprehensive animated apply test suite (21 tests) covering section insert/delete/move/replace, item reorder and cross-section moves, non-structural reload/reconfigure fast path, structural changes with deferred reload/reconfigure markers, background diff with large datasets (≥1,000 items), and rapid-fire serialization edge cases
+
 ## [0.6.2] - 2026-02-19
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Adds 21 new tests to `DataSourceLifecycleTests` covering all four animated code paths in `performApply`:
  - **Section structural ops**: insert, delete, move, full replacement, simultaneous insert+delete+move
  - **Item moves**: within-section reorder, cross-section move, moves combined with inserts/deletes
  - **Non-structural fast path**: reload-only, reconfigure-only, section-reload, mixed reload+reconfigure
  - **Structural + completion handler**: structural changes with deferred reload/reconfigure markers
  - **Background diff**: large datasets (≥1,000 items) triggering `Task.detached` diff path
  - **Stress/edge cases**: rapid-fire serialization, grow/shrink cycles, reloadData→animated transition, identical snapshot no-op
- Adds UICollectionView data source protocol assertions (`numberOfSections`, `numberOfItemsInSection`) to representative tests
- Documents windowless testing limitation for deferred reload/reconfigure operations
- Updates ABOUTME header and changelog

## Test plan

- [x] `make test-listkit` — 207 tests pass (186 existing + 21 new)
- [x] `make format` — 0 files reformatted
- [x] `make lint` — 0 violations