### PR TITLE
Adopt plural context menu delegate in example app

### DIFF
--- a/Example/Sources/ListKitChatExampleViewController.swift
+++ b/Example/Sources/ListKitChatExampleViewController.swift
@@ -38,10 +38,11 @@ final class ListKitChatExampleViewController: UIViewController, UICollectionView
 
   func collectionView(
     _: UICollectionView,
-    contextMenuConfigurationForItemAt indexPath: IndexPath,
+    contextMenuConfigurationForItemsAt indexPaths: [IndexPath],
     point _: CGPoint
   ) -> UIContextMenuConfiguration? {
     guard
+      let indexPath = indexPaths.first,
       let ref = dataSource.itemIdentifier(for: indexPath),
       let model = store.model(for: ref.id)
     else { return nil }


### PR DESCRIPTION
## Summary
- The chat example (`ListKitChatExampleViewController`) was still using the singular `contextMenuConfigurationForItemAt` delegate method, deprecated in iOS 16
- Migrated to the plural `contextMenuConfigurationForItemsAt` variant, consistent with the library's own conformances (updated in #68)

## Test plan
- [ ] Build the Example app and verify context menu still appears on long-press of a chat bubble
- [ ] Verify no deprecation warnings from this file