### PR TITLE
Fix Swift Package Manager installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the Swift Package Manager installation URL and minimum version in the README ([#71](https://github.com/Iron-Ham/Lists/issues/71))
+
 ## [0.6.6] - 2026-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A fast, pure-Swift diffable data source for `UICollectionView`. Drop-in replacem
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Iron-Ham/ListKit", from: "0.6.1"),
+    .package(url: "https://github.com/Iron-Ham/Lists", from: "0.6.6"),
 ]
 ```
 


### PR DESCRIPTION
## Summary

- update the Swift Package Manager URL to the canonical `Iron-Ham/Lists` repository
- update the minimum package version from `0.6.1` to the latest stable release, `0.6.6`
- record the documentation correction in the changelog

## Why

The README still referenced the repository's former `ListKit` URL and an outdated release, which could misdirect users configuring the package dependency.

## Impact

Users can copy the installation snippet directly and resolve the current package release from the correct repository.

Fixes #71

## Test plan

- [x] `make format`
- [x] `make test`
- [x] `git diff --check`
- [x] verified the upstream `0.6.6` tag exists